### PR TITLE
refactor: removed pushgateway, now prometheus scrape metrics for back…

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,20 +39,20 @@ services:
     networks:
       - metrics_network
     depends_on:
-      - pushgateway
+      - backend
 
-  pushgateway:
-    image: prom/pushgateway:latest
-    container_name: metrics_pushgateway
-    ports:
-      - "9091:9091"
-    volumes:
-      - pushgateway_data:/pushgateway
-    networks:
-      - metrics_network
-    command:
-      - "--persistence.file=/pushgateway/data"
-      - "--persistence.interval=5m"
+  # pushgateway:
+  #   image: prom/pushgateway:latest
+  #   container_name: metrics_pushgateway
+  #   ports:
+  #     - "9091:9091"
+  #   volumes:
+  #     - pushgateway_data:/pushgateway
+  #   networks:
+  #     - metrics_network
+  #   command:
+  #     - "--persistence.file=/pushgateway/data"
+  #     - "--persistence.interval=5m"
 
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
#Reference
why pushgateway is bad practice: https://prometheus.io/docs/practices/pushing/

#Summary
- removed docker pushgateway image
- prometheus will scrape from backend's /metrics endpoint. No extra layer needed for pulling metrics from client.

closes #19 