### PR TITLE
First step in Keycloak migration 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,37 @@ services:
     profiles:
       - local-db # Only start with: docker compose --profile local-db up
 
+  # Keycloak Identity Provider (uses same cloud Postgres as backend)
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    container_name: metrics_keycloak
+    command: start
+    env_file:
+      - .env
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://${DB_HOST}:${DB_PORT:-5432}/${DB_NAME}
+      KC_DB_USERNAME: ${DB_USER}
+      KC_DB_PASSWORD: ${DB_PASSWORD}
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8180:8080"
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+    networks:
+      - metrics_network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
   # ... (prometheus, pushgateway, grafana stay the same) ...
   prometheus:
     image: prom/prometheus:latest
@@ -97,6 +128,10 @@ services:
       - GRAFANA_URL=${GRAFANA_URL:-http://localhost:3001}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - API_BASE_URL=${API_BASE_URL:-http://localhost:3000}
+      # Keycloak configuration
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-metrics}
+      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-metrics-client}
     volumes:
       - ../backend:/app
       - /app/node_modules
@@ -127,6 +162,7 @@ volumes:
   prometheus_data:
   pushgateway_data:
   grafana_data:
+  keycloak_data:  # Keycloak persistent storage
 
 networks:
   metrics_network:


### PR DESCRIPTION
## Summary 
Keycloak was added as an identity provider to the stack. Keycloak runs in Docker and uses the **existing cloud Postgres** (no local Postgres). This is the first step of the Keycloak auth migration.

## Why to use Keycloak?
 - It is an open-source Identity and Access Management (IAM) solution. 
 - It handles authentication, authorization, and user management for applications securely and efficiently. 
 - It supports SSO, OAuth2, OpenID Connect, social logins, and multi-tenancy out of the box.

## What happens if authentication is done manually?
If you roll your own authentication system, you have to build everything from scratch or using libraries:

You will need to manage:
✔ Password storage & hashing
✔ Session management
✔ Token generation and refresh
✔ Role/permission logic
✔ Login flows
✔ Security hardening
✔ Integration with other systems
✔ Password recovery
✔ MFA (Multi-Factor Authentication)
✔ Auditing & logs

And every time you need a new login feature — you add more code and more security risk.
 


