### PR TITLE
Feat: Breadcrumbs for secondary navigation

### DIFF
--- a/frontend/src/assets/icons/HomeIcon.jsx
+++ b/frontend/src/assets/icons/HomeIcon.jsx
@@ -1,0 +1,19 @@
+import { defaultSvgProps } from './constants';
+
+/**
+ * Home / house outline icon for breadcrumb and navigation.
+ * Matches stroke style of other icons (currentColor, round caps).
+ */
+export function HomeIcon({ size = 20, ...props }) {
+  return (
+    <svg {...defaultSvgProps} viewBox="0 0 24 24" width={size} height={size} {...props}>
+      <path
+        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/assets/icons/index.jsx
+++ b/frontend/src/assets/icons/index.jsx
@@ -30,6 +30,7 @@ export { CopyIcon } from './CopyIcon';
 export { ArchiveIcon } from './ArchiveIcon';
 export { ChevronLeftIcon } from './ChevronLeftIcon';
 export { ChevronRightIcon } from './ChevronRightIcon';
+export { HomeIcon } from './HomeIcon';
 export { RefreshIcon } from './RefreshIcon';
 export { ShieldIcon } from './ShieldIcon';
 export { LockIcon } from './LockIcon';

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.css
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.css
@@ -1,0 +1,138 @@
+/* Breadcrumbs – professional pattern (Linear / Vercel / Stripe style) */
+
+.breadcrumbs {
+  margin-bottom: 1.5rem;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.breadcrumbs-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.breadcrumbs-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.breadcrumbs-separator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  margin: 0 0.5rem;
+  flex-shrink: 0;
+}
+
+.breadcrumbs-separator svg {
+  opacity: 0.7;
+}
+
+.breadcrumbs-icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+}
+
+.breadcrumbs-icon,
+.breadcrumbs-icon-current {
+  flex-shrink: 0;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.breadcrumbs-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  border-radius: 6px;
+  padding: 0.25rem 0.375rem;
+  margin: -0.25rem -0.375rem;
+}
+
+.breadcrumbs-link:hover {
+  color: var(--primary);
+}
+
+.breadcrumbs-link:hover .breadcrumbs-icon {
+  color: var(--primary);
+  opacity: 1;
+}
+
+.breadcrumbs-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.breadcrumbs-current {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.breadcrumbs-current .breadcrumbs-icon-current {
+  color: var(--primary);
+  opacity: 1;
+}
+
+.breadcrumbs-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+}
+
+@media (min-width: 769px) {
+  .breadcrumbs-label {
+    max-width: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .breadcrumbs {
+    margin-bottom: 1.25rem;
+    padding: 0.625rem 0.875rem;
+    border-radius: 8px;
+  }
+
+  .breadcrumbs-list {
+    font-size: 0.8125rem;
+  }
+
+  .breadcrumbs-separator {
+    margin: 0 0.375rem;
+  }
+
+  .breadcrumbs-icon-wrap {
+    margin-right: 0.375rem;
+  }
+
+  .breadcrumbs-label {
+    max-width: 8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .breadcrumbs-label {
+    max-width: 6rem;
+  }
+}

--- a/frontend/src/components/Breadcrumbs/index.jsx
+++ b/frontend/src/components/Breadcrumbs/index.jsx
@@ -1,0 +1,162 @@
+import { Link, useLocation } from 'react-router-dom';
+import {
+  HomeIcon,
+  ChevronRightIcon,
+  BarChartIcon,
+  KeyIcon,
+  RocketIcon,
+  DocumentIcon,
+  EditIcon,
+  AddCircleIcon,
+} from '@/assets/icons';
+import './Breadcrumbs.css';
+
+/** Icon id per route path for contextual breadcrumb icons */
+const PATH_ICONS = {
+  '/': 'home',
+  '/metric-configs': 'barChart',
+  '/metric-configs/new': 'plus',
+  '/api-keys': 'key',
+  '/code-generation': 'rocket',
+};
+
+function getIconForPath(pathname, label) {
+  if (PATH_ICONS[pathname]) return PATH_ICONS[pathname];
+  if (pathname.match(/^\/metric-configs\/[^/]+\/edit$/)) return 'edit';
+  return 'document';
+}
+
+const ICON_SIZE = 16;
+
+function CrumbIcon({ iconId, isCurrent }) {
+  const iconClass = isCurrent ? 'breadcrumbs-icon-current' : 'breadcrumbs-icon';
+  const props = { size: ICON_SIZE, className: iconClass };
+  switch (iconId) {
+    case 'home':
+      return <HomeIcon {...props} />;
+    case 'barChart':
+      return <BarChartIcon {...props} />;
+    case 'key':
+      return <KeyIcon {...props} />;
+    case 'rocket':
+      return <RocketIcon {...props} />;
+    case 'plus':
+      return <AddCircleIcon {...props} />;
+    case 'edit':
+      return <EditIcon {...props} />;
+    default:
+      return <DocumentIcon {...props} />;
+  }
+}
+
+/**
+ * Build breadcrumb items from current pathname.
+ * Returns array of { path, label, isLast, iconId }.
+ */
+function buildCrumbs(pathname) {
+  const items = [];
+
+  items.push({
+    path: '/',
+    label: 'Dashboard',
+    isLast: pathname === '/',
+    iconId: 'home',
+  });
+
+  if (pathname === '/') return items;
+
+  if (pathname.startsWith('/metric-configs')) {
+    items.push({
+      path: '/metric-configs',
+      label: 'Metric Configs',
+      isLast: pathname === '/metric-configs',
+      iconId: 'barChart',
+    });
+    if (pathname === '/metric-configs/new') {
+      items.push({
+        path: '/metric-configs/new',
+        label: 'New Configuration',
+        isLast: true,
+        iconId: 'plus',
+      });
+    } else if (pathname.match(/^\/metric-configs\/[^/]+\/edit$/)) {
+      items[items.length - 1].isLast = false;
+      items.push({
+        path: pathname,
+        label: 'Edit Configuration',
+        isLast: true,
+        iconId: 'edit',
+      });
+    }
+    return items;
+  }
+
+  if (pathname === '/api-keys') {
+    items.push({ path: '/api-keys', label: 'API Keys', isLast: true, iconId: 'key' });
+    return items;
+  }
+
+  if (pathname === '/code-generation') {
+    items.push({
+      path: '/code-generation',
+      label: 'Code Gen',
+      isLast: true,
+      iconId: 'rocket',
+    });
+    return items;
+  }
+
+  const label =
+    {
+      '/': 'Dashboard',
+      '/metric-configs': 'Metric Configs',
+      '/api-keys': 'API Keys',
+      '/code-generation': 'Code Gen',
+    }[pathname] ||
+    (pathname.match(/^\/metric-configs\/[^/]+\/edit$/) ? 'Edit Configuration' : null);
+  if (label) {
+    items.push({ path: pathname, label, isLast: true, iconId: getIconForPath(pathname, label) });
+  }
+  return items;
+}
+
+function Breadcrumbs() {
+  const location = useLocation();
+  const pathname = location.pathname;
+  const crumbs = buildCrumbs(pathname);
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav className="breadcrumbs" aria-label="Breadcrumb">
+      <ol className="breadcrumbs-list">
+        {crumbs.map((crumb, index) => (
+          <li key={`${crumb.path}-${index}`} className="breadcrumbs-item">
+            {index > 0 && (
+              <span className="breadcrumbs-separator" aria-hidden="true">
+                <ChevronRightIcon size={14} />
+              </span>
+            )}
+            {crumb.isLast ? (
+              <span className="breadcrumbs-current" aria-current="page">
+                <span className="breadcrumbs-icon-wrap">
+                  <CrumbIcon iconId={crumb.iconId} isCurrent />
+                </span>
+                <span className="breadcrumbs-label">{crumb.label}</span>
+              </span>
+            ) : (
+              <Link to={crumb.path} className="breadcrumbs-link">
+                <span className="breadcrumbs-icon-wrap">
+                  <CrumbIcon iconId={crumb.iconId} isCurrent={false} />
+                </span>
+                <span className="breadcrumbs-label">{crumb.label}</span>
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumbs;

--- a/frontend/src/components/Layout/index.jsx
+++ b/frontend/src/components/Layout/index.jsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useThemeStore } from '@/store/themeStore';
 import Logo from '@/components/Logo';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import { BellIcon, MoonIcon, SunIcon } from '@/assets/icons';
 import Footer from './Footer';
 import './Layout.css';
@@ -93,6 +94,7 @@ function Layout() {
       </nav>
       <main className="main-content">
         <div className="container">
+          <Breadcrumbs />
           <Outlet />
         </div>
       </main>


### PR DESCRIPTION
## Summary
Introduces a route-aware breadcrumb component and wires it into the main layout so users can see where they are and quickly jump back to parent sections.

## Why this change
- **Orientation** – Users can see where they are in the app (e.g. Dashboard → Metric Configs → Edit Configuration) at a glance.
- **Faster navigation** – One-click jump to any parent level instead of relying on the main nav or back button, especially in flows like New/Edit metric config.
- **Familiar pattern** – Breadcrumbs match common dashboard/admin UX and reduce cognitive load.
- **Accessibility** – Semantic `<nav aria-label="Breadcrumb">` and `aria-current="page"` give assistive tech users a clear hierarchy and easy way to move up the tree.
- **Future-proofing** – As we add more nested routes, breadcrumbs scale without changing the top-level nav.

## Testing
- [ ] Breadcrumbs show correctly on `/`, `/metric-configs`, `/metric-configs/new`, `/api-keys`, `/code-generation`, and metric-config edit routes.
- [ ] Current page is not a link; parent segments are links and navigate correctly.
- [ ] Icons and labels match each route; separators render between crumbs.
- [ ] Layout and truncation look correct on narrow viewports.
- [ ] No console errors; focus/hover states work and theme variables apply.

## Screenshots
<img width="1440" height="784" alt="Screenshot 2026-02-04 at 10 52 39 AM" src="https://github.com/user-attachments/assets/eff563b5-2a45-4f4e-8334-64e87153238d" />
