### PR TITLE
Fully implemented authentication(Keycloak)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -30,9 +30,10 @@ console.log(`   - Database Name: ${process.env.DB_NAME || "metrics_db"}`);
 console.log(`   - Database User: ${process.env.DB_USER || "postgres"}`);
 console.log(`   - Database SSL: ${process.env.DB_SSL || "false"}`);
 console.log(`   - Frontend URL: ${process.env.FRONTEND_URL || "http://localhost:5173"}`);
+console.log(`   - Keycloak Issuer: ${process.env.KEYCLOAK_ISSUER_URI || "(not set)"}`);
 
-// Validate required environment variables
-const requiredEnvVars = ['DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD'];
+// Validate required environment variables (Keycloak required for auth)
+const requiredEnvVars = ['DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'KEYCLOAK_ISSUER_URI'];
 const missingVars = requiredEnvVars.filter(varName => !process.env[varName]);
 
 if (missingVars.length > 0) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "crypto": "^1.0.1",
         "dotenv": "^16.3.1",
         "express": "^5.2.1",
+        "express-oauth2-jwt-bearer": "^1.7.4",
         "express-rate-limit": "^7.1.5",
         "express-validator": "^7.0.1",
         "helmet": "^7.1.0",
@@ -381,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -418,6 +418,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-oauth2-jwt-bearer": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/express-oauth2-jwt-bearer/-/express-oauth2-jwt-bearer-1.7.4.tgz",
+      "integrity": "sha512-teO/eyvU8OkJXiP4cRuoJMrp31nNvjnL47MIkso0D/21AqUGv1O+VEiLisrDA8xjkaCBTufYnV1zepCOCLK4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.5"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0 || ^20.2.0 || ^22.1.0 || ^24.0.0"
       }
     },
     "node_modules/express-rate-limit": {
@@ -707,6 +719,15 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -986,7 +1007,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "crypto": "^1.0.1",
     "dotenv": "^16.3.1",
     "express": "^5.2.1",
+    "express-oauth2-jwt-bearer": "^1.7.4",
     "express-rate-limit": "^7.1.5",
     "express-validator": "^7.0.1",
     "helmet": "^7.1.0",

--- a/backend/src/database/connection.js
+++ b/backend/src/database/connection.js
@@ -171,6 +171,19 @@ const runMigrations = async () => {
     await query(migration);
   }
 
+  // Keycloak migration: add keycloak_sub to users, make password_hash optional (no local passwords)
+  const keycloakMigrations = [
+    `ALTER TABLE users ADD COLUMN IF NOT EXISTS keycloak_sub VARCHAR(255) UNIQUE`,
+    `ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL`,
+  ];
+  for (const m of keycloakMigrations) {
+    try {
+      await query(m);
+    } catch (e) {
+      if (e.code !== '42701' && e.code !== '23502') console.error('Keycloak migration warning:', e.message);
+    }
+  }
+
   console.log("✅ Migrations completed");
 };
 

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,21 +1,68 @@
-import jwt from 'jsonwebtoken';
+/**
+ * Keycloak-based authentication middleware.
+ * Validates Keycloak-issued access tokens (JWKS) and resolves/creates app user by keycloak_sub.
+ * No local passwords; identity is fully delegated to Keycloak.
+ */
+import { auth } from 'express-oauth2-jwt-bearer';
 import { query } from '../database/connection.js';
 import { UnauthorizedError } from './errorHandler.js';
 
-export const authenticate = async (req, res, next) => {
+const KEYCLOAK_ISSUER_URI = process.env.KEYCLOAK_ISSUER_URI;
+/** When set (e.g. in Docker), backend fetches JWKS from this URL (reachable from container). Token iss still must match KEYCLOAK_ISSUER_URI. */
+const KEYCLOAK_INTERNAL_ISSUER_URI = process.env.KEYCLOAK_INTERNAL_ISSUER_URI;
+const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID || 'metrics-client';
+// express-oauth2-jwt-bearer requires audience. Keycloak may put client_id or "account" in aud.
+const KEYCLOAK_AUDIENCE = process.env.KEYCLOAK_AUDIENCE;
+const audienceList = KEYCLOAK_AUDIENCE
+  ? [KEYCLOAK_AUDIENCE]
+  : [KEYCLOAK_CLIENT_ID, 'account'];
+
+const authOptions = {
+  audience: audienceList,
+  tokenSigningAlg: 'RS256',
+};
+if (KEYCLOAK_INTERNAL_ISSUER_URI) {
+  authOptions.issuer = KEYCLOAK_ISSUER_URI?.replace(/\/$/, '');
+  authOptions.jwksUri = `${KEYCLOAK_INTERNAL_ISSUER_URI.replace(/\/$/, '')}/protocol/openid-connect/certs`;
+} else {
+  authOptions.issuerBaseURL = KEYCLOAK_ISSUER_URI;
+}
+const validateKeycloakJwt = auth(authOptions);
+
+/**
+ * Resolve app user from Keycloak token payload.
+ * Finds user by keycloak_sub (token 'sub' claim); creates one on first login.
+ * Sets req.user = { id, email, name } (local users.id for FK consistency).
+ */
+export const resolveUserFromToken = async (req, res, next) => {
   try {
-    const authHeader = req.headers.authorization;
-    
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      throw new UnauthorizedError('No token provided');
+    if (!req.auth?.payload) {
+      throw new UnauthorizedError('Invalid or missing token');
+    }
+    const payload = req.auth.payload;
+    const keycloakSub = payload.sub; // Keycloak user ID (UUID)
+    const email = payload.email || payload.preferred_username || null;
+    const name = payload.name || [payload.given_name, payload.family_name].filter(Boolean).join(' ') || null;
+
+    if (!keycloakSub) {
+      throw new UnauthorizedError('Token missing subject');
     }
 
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production');
+    let result = await query(
+      'SELECT id, email, name FROM users WHERE keycloak_sub = $1',
+      [keycloakSub]
+    );
 
-    // Verify user still exists
-    const result = await query('SELECT id, email, name FROM users WHERE id = $1', [decoded.userId]);
-    
+    if (result.rows.length === 0) {
+      // First login: create app user linked to Keycloak (no password)
+      result = await query(
+        `INSERT INTO users (keycloak_sub, email, name) VALUES ($1, $2, $3)
+         ON CONFLICT (keycloak_sub) DO UPDATE SET email = EXCLUDED.email, name = EXCLUDED.name, updated_at = CURRENT_TIMESTAMP
+         RETURNING id, email, name`,
+        [keycloakSub, email || `keycloak-${keycloakSub}`, name]
+      );
+    }
+
     if (result.rows.length === 0) {
       throw new UnauthorizedError('User not found');
     }
@@ -23,17 +70,24 @@ export const authenticate = async (req, res, next) => {
     req.user = result.rows[0];
     next();
   } catch (error) {
-    if (error.name === 'JsonWebTokenError' || error.name === 'TokenExpiredError') {
-      return next(new UnauthorizedError('Invalid or expired token'));
-    }
     next(error);
   }
 };
 
+/**
+ * Protect routes with Keycloak JWT + app user resolution.
+ * Use this where you previously used authenticate (Bearer token required).
+ */
+export const authenticate = [validateKeycloakJwt, resolveUserFromToken];
+
+/**
+ * API key authentication (unchanged): for server-to-server / tracking scripts.
+ * Still resolves req.user from api_keys join users (local users.id).
+ */
 export const authenticateApiKey = async (req, res, next) => {
   try {
     const apiKey = req.headers['x-api-key'] || req.query.api_key;
-    
+
     if (!apiKey) {
       throw new UnauthorizedError('API key required');
     }

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -10,8 +10,8 @@ export const errorHandler = (err, req, res, next) => {
     });
   }
 
-  // Authentication errors
-  if (err.name === 'UnauthorizedError' || err.name === 'JsonWebTokenError') {
+  // Authentication errors (custom + JWT + Keycloak/OAuth2 JWT bearer)
+  if (err.status === 401 || err.name === 'UnauthorizedError' || err.name === 'JsonWebTokenError' || err.code === 'invalid_token') {
     return res.status(401).json({
       success: false,
       error: 'Unauthorized',

--- a/backend/src/routes/apikey.routes.js
+++ b/backend/src/routes/apikey.routes.js
@@ -8,8 +8,8 @@ import { BadRequestError, NotFoundError } from '../middleware/errorHandler.js';
 
 const router = express.Router();
 
-// All routes require authentication
-router.use(authenticate);
+// All routes require Keycloak JWT authentication
+router.use(...authenticate);
 router.use(apiLimiter);
 
 // Generate API key

--- a/backend/src/routes/codeGeneration.routes.js
+++ b/backend/src/routes/codeGeneration.routes.js
@@ -8,8 +8,8 @@ import { generateMinimalSnippet } from '../services/codeGenerator.service.js';
 
 const router = express.Router();
 
-// All routes require authentication
-router.use(authenticate);
+// All routes require Keycloak JWT authentication
+router.use(...authenticate);
 router.use(apiLimiter);
 
 /**

--- a/backend/src/routes/metricconfig.routes.js
+++ b/backend/src/routes/metricconfig.routes.js
@@ -7,8 +7,8 @@ import { BadRequestError, NotFoundError } from '../middleware/errorHandler.js';
 
 const router = express.Router();
 
-// All routes require authentication
-router.use(authenticate);
+// All routes require Keycloak JWT authentication
+router.use(...authenticate);
 router.use(apiLimiter);
 
 const METRIC_TYPES = ['counter', 'gauge', 'histogram', 'summary'];

--- a/backend/src/routes/metrics.routes.js
+++ b/backend/src/routes/metrics.routes.js
@@ -153,7 +153,7 @@ router.post('/',
  * Note: Actual Prometheus metrics are exposed at /metrics endpoint
  */
 router.get('/',
-  authenticate,
+  ...authenticate,
   async (req, res, next) => {
     try {
       res.json({

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,9 @@ services:
     profiles:
       - local-db # Only start with: docker compose --profile local-db up
 
-  # Keycloak Identity Provider (uses same cloud Postgres as backend)
+  # Keycloak Identity Provider
+  # Default: dev-file DB (no Postgres needed) so the admin portal starts reliably.
+  # Set KEYCLOAK_USE_POSTGRES=true and ensure DB_* are set to use your Postgres instead.
   keycloak:
     image: quay.io/keycloak/keycloak:24.0
     container_name: metrics_keycloak
@@ -32,14 +34,17 @@ services:
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
-      KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://${DB_HOST}:${DB_PORT:-5432}/${DB_NAME}
-      KC_DB_USERNAME: ${DB_USER}
-      KC_DB_PASSWORD: ${DB_PASSWORD}
+      # Hostname so browser at http://localhost:8180 works (no redirect to keycloak:8080)
+      KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-localhost}
+      KC_HOSTNAME_PORT: ${KEYCLOAK_HOSTNAME_PORT:-8180}
       KC_HOSTNAME_STRICT: "false"
       KC_HOSTNAME_STRICT_HTTPS: "false"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
+      KC_PROXY: "edge"
+      # dev-file = no Postgres needed; Keycloak starts and portal works at http://localhost:8180
+      # To use Postgres instead, set KEYCLOAK_DB=postgres and KC_DB_* in .env
+      KC_DB: ${KEYCLOAK_DB:-dev-file}
     ports:
       - "8180:8080"
     volumes:
@@ -51,7 +56,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 60s
+      start_period: 90s
     restart: unless-stopped
   # ... (prometheus, pushgateway, grafana stay the same) ...
   prometheus:
@@ -128,13 +133,21 @@ services:
       - GRAFANA_URL=${GRAFANA_URL:-http://localhost:3001}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - API_BASE_URL=${API_BASE_URL:-http://localhost:3000}
-      # Keycloak configuration
-      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
+      # Keycloak: issuer for JWT validation (must match token iss from browser login at KEYCLOAK_PUBLIC_URL).
+      - KEYCLOAK_ISSUER_URI=${KEYCLOAK_ISSUER_URI:-http://localhost:8180/realms/metrics}
+      # Internal URL for token exchange and JWKS (backend in Docker cannot reach localhost; use keycloak service).
+      - KEYCLOAK_INTERNAL_ISSUER_URI=${KEYCLOAK_INTERNAL_ISSUER_URI:-http://keycloak:8080/realms/metrics}
+      - KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_URL:-http://localhost:8180}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-metrics}
+      - KEYCLOAK_AUDIENCE=${KEYCLOAK_AUDIENCE:-}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-metrics-client}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8180}
     volumes:
       - ../backend:/app
       - /app/node_modules
+    # So backend in Docker can reach Keycloak at host (for JWKS when KEYCLOAK_ISSUER_URI uses host.docker.internal)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # Remove postgres dependency if using external DB only
     # depends_on:
     #   postgres:

--- a/docs/KEYCLOAK.md
+++ b/docs/KEYCLOAK.md
@@ -1,0 +1,74 @@
+# Keycloak Authentication
+
+The backend uses **Keycloak** for authentication. Login and signup (user registration) happen in Keycloak; the backend validates Keycloak-issued access tokens and links them to app users in PostgreSQL.
+
+## Required Environment Variables
+
+In `docker/.env` (used by backend and Keycloak containers):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `KEYCLOAK_ISSUER_URI` | Yes | Full realm issuer URL for JWT validation and token exchange (backend fetches JWKS and calls token endpoint here). From Docker backend use `http://host.docker.internal:8180/realms/<realm>` when Keycloak is on host. |
+| `KEYCLOAK_PUBLIC_URL` | No (default: http://localhost:8180) | URL the **browser** uses to reach Keycloak (login/register). Must match Keycloak host/port (e.g. http://localhost:8180). |
+| `KEYCLOAK_REALM` | No (default: metrics) | Realm name; used with KEYCLOAK_PUBLIC_URL for frontend redirect URLs. |
+| `KEYCLOAK_CLIENT_ID` | No (default: metrics-client) | Keycloak client ID; used in login/register URLs and token exchange. |
+| `KEYCLOAK_CLIENT_SECRET` | No | Client secret (only if client is confidential). Required for token exchange when client authentication is ON. |
+| `KEYCLOAK_AUDIENCE` | No | Token audience; if unset, backend accepts `KEYCLOAK_CLIENT_ID` or `account` in token `aud` claim. |
+| `KEYCLOAK_ADMIN` | No | Keycloak admin username (default: admin). |
+| `KEYCLOAK_ADMIN_PASSWORD` | No | Keycloak admin password (default: admin). |
+| `FRONTEND_URL` | No | Frontend base URL for redirect_uri (default: http://localhost:5173). Must match Valid redirect URIs in Keycloak (e.g. `http://localhost:5173/callback`). |
+
+## Keycloak Configuration
+
+1. **Create a realm** (e.g. `metrics`).
+2. **Create a client** (e.g. `metrics-client`):
+   - Client authentication: ON if you use a client secret (backend can validate with audience).
+   - Authorization: OFF unless you use Keycloak authorization.
+   - Valid redirect URIs: `http://localhost:5173/*` (or your frontend URL + `/callback`).
+   - Web origins: `http://localhost:5173` (or your frontend origin).
+3. **Enable registration** (optional): Realm settings → Login → User registration ON.
+4. **Token issuer**: The issuer in access tokens must match `KEYCLOAK_ISSUER_URI`. When users log in via the browser at `http://localhost:8180`, Keycloak sets the token issuer from the request host. So either:
+   - Set `KEYCLOAK_ISSUER_URI=http://host.docker.internal:8180/realms/metrics` and ensure Keycloak is reachable at that URL from the backend container, or
+   - Run Keycloak with a hostname that matches what the backend will use (e.g. same hostname for frontend and backend).
+
+## Backend Auth Endpoints
+
+- **GET /api/v1/auth/config** – Public; returns `{ loginUrl, registerUrl, logoutUrl, redirectUri, issuerUri, clientId }` for the frontend to redirect users to Keycloak.
+- **POST /api/v1/auth/token** – Public; exchanges authorization code for tokens. Body: `{ code, redirect_uri }`. Returns `{ access_token, refresh_token }`. Used to avoid CORS (browser does not call Keycloak token endpoint directly).
+- **GET /api/v1/auth/me** – Returns current user (requires `Authorization: Bearer <access_token>`). Use after login to get app user `{ id, email, name }`.
+
+## Login Flow (Authorization Code)
+
+1. User clicks "Sign in with Keycloak" → frontend calls **GET /api/v1/auth/config**, then redirects to `loginUrl`.
+2. User logs in at Keycloak (no password sent to backend).
+3. Keycloak redirects to `FRONTEND_URL/callback?code=...`.
+4. Frontend calls **POST /api/v1/auth/token** with `{ code, redirect_uri: FRONTEND_URL/callback }`; backend exchanges with Keycloak and returns tokens.
+5. Frontend stores tokens, calls **GET /api/v1/auth/me** with `Authorization: Bearer <access_token>`, then redirects to dashboard.
+6. All subsequent API calls send `Authorization: Bearer <access_token>` (client interceptor).
+
+## Signup Flow
+
+1. User clicks "Sign up with Keycloak" → frontend calls **GET /api/v1/auth/config**, then redirects to `registerUrl` (Keycloak user registration page).
+2. Enable **User registration** in Keycloak: Realm settings → Login → User registration ON.
+3. After registration, Keycloak redirects to `/callback?code=...`; same token exchange and /me as login.
+
+## Docker Networking
+
+- Backend and Keycloak are on the same Docker network (`metrics_network`). From the backend container, Keycloak is reachable at `http://keycloak:8080`.
+- If the frontend runs on the host and users log in at `http://localhost:8180`, tokens will have issuer `http://localhost:8180/realms/metrics`. The backend (in Docker) cannot reach `localhost:8180`. Set `KEYCLOAK_ISSUER_URI=http://host.docker.internal:8180/realms/metrics` so the backend fetches JWKS from the host (Docker Desktop / Linux with extra_hosts).
+
+## Troubleshooting
+
+### "Back to login after signing in at Keycloak"
+
+1. **Valid redirect URIs**: In Keycloak Admin → your realm → Client `metrics-client` → **Valid redirect URIs** must include `http://localhost:5173/callback` (or your frontend URL + `/callback`). **Web origins** must include `http://localhost:5173`.
+2. **Issuer match**: The token issuer (set by Keycloak from the login URL) must match `KEYCLOAK_ISSUER_URI`. When you log in at `http://localhost:8180`, the issuer is `http://localhost:8180/realms/<realm>`. So set `KEYCLOAK_ISSUER_URI=http://localhost:8180/realms/metrics`. If the backend runs in Docker, use `http://host.docker.internal:8180/realms/metrics` and set Keycloak hostname to `host.docker.internal`.
+3. **Backend on host**: If the backend runs with `npm run dev` (on the host), it can reach `localhost:8180`; keep `KEYCLOAK_ISSUER_URI=http://localhost:8180/realms/metrics`.
+
+### "Token exchange failed" or CORS on callback
+
+- The frontend does **not** call Keycloak's token endpoint from the browser (CORS would block it). It calls **POST /api/v1/auth/token** on the backend; the backend exchanges the code with Keycloak. Ensure the backend can reach `KEYCLOAK_ISSUER_URI` (e.g. from Docker use `host.docker.internal`).
+
+### "Invalid token" or "Invalid audience" on /me
+
+- Backend accepts token `aud` equal to `KEYCLOAK_CLIENT_ID` or `account` by default. If your token has a different `aud`, set `KEYCLOAK_AUDIENCE` to that value (or add it in Keycloak Client → Advanced → Audience).

--- a/docs/changes-since-last-commit.md
+++ b/docs/changes-since-last-commit.md
@@ -1,0 +1,92 @@
+## Changes since last commit (modified files only)
+
+_This document lists only files marked as **M** (modified) in `git status`, excluding untracked (`??`) files._
+
+- **backend/index.js**
+  - Logged the configured Keycloak issuer URL at startup.
+  - Updated required environment variable validation to also enforce `KEYCLOAK_ISSUER_URI`.
+
+- **backend/package.json**
+  - Added `express-oauth2-jwt-bearer` dependency for Keycloak JWT validation.
+
+- **backend/package-lock.json**
+  - Locked versions for `express-oauth2-jwt-bearer` and its dependency `jose`, and adjusted some existing dependency metadata to match the updated dependency graph.
+
+- **backend/src/database/connection.js**
+  - Added lightweight migrations to support Keycloak:
+    - New `keycloak_sub` column on `users` (unique identifier for Keycloak users).
+    - Made `password_hash` optional to support passwordless, Keycloak-only accounts.
+
+- **backend/src/middleware/auth.middleware.js**
+  - Replaced custom JWT handling with `express-oauth2-jwt-bearer` validating Keycloak-issued tokens.
+  - Introduced `resolveUserFromToken` to look up or create app users by `keycloak_sub` and attach `{ id, email, name }` on `req.user`.
+  - Exported `authenticate` as a middleware chain (`[validateKeycloakJwt, resolveUserFromToken]`) and kept API key auth unchanged.
+
+- **backend/src/middleware/errorHandler.js**
+  - Broadened authentication error handling to treat Keycloak/OAuth2 JWT bearer errors (`status === 401` or `code === 'invalid_token'`) as 401 Unauthorized responses.
+
+- **backend/src/routes/apikey.routes.js**
+  - Updated route protection to use the new Keycloak-based `authenticate` middleware (spread as `...authenticate`).
+
+- **backend/src/routes/auth.routes.js**
+  - Replaced email/password-based auth with Keycloak-centric endpoints:
+    - `GET /auth/me` now uses Keycloak JWT + `authenticate` to return the current user.
+    - `GET /auth/config` returns Keycloak login, register, and logout URLs plus metadata (issuer, client, redirect URI).
+    - `POST /auth/token` exchanges an authorization code for access/refresh tokens via Keycloak, enforcing expected `redirect_uri`.
+  - Removed local signup, signin, refresh token, and password reset endpoints.
+
+- **backend/src/routes/codeGeneration.routes.js**
+  - Switched to Keycloak JWT authentication via the new `authenticate` middleware (`router.use(...authenticate)`).
+
+- **backend/src/routes/metricconfig.routes.js**
+  - Switched to Keycloak JWT authentication via the new `authenticate` middleware (`router.use(...authenticate)`).
+
+- **backend/src/routes/metrics.routes.js**
+  - Updated the metrics `GET /` route to spread the new `authenticate` middleware (`...authenticate`).
+
+- **docker/docker-compose.yml**
+  - Reworked Keycloak configuration:
+    - Defaulted to `KC_DB=dev-file` so Keycloak can run without Postgres for local dev.
+    - Added `KC_HOSTNAME`, `KC_HOSTNAME_PORT`, and `KC_PROXY` to make the portal work reliably at `http://localhost:8180`.
+    - Increased `start_period` for the Keycloak healthcheck.
+  - Updated backend service environment:
+    - Introduced `KEYCLOAK_ISSUER_URI`, `KEYCLOAK_INTERNAL_ISSUER_URI`, `KEYCLOAK_PUBLIC_URL`, `KEYCLOAK_AUDIENCE`, and `KEYCLOAK_CLIENT_ID` for Keycloak integration.
+    - Added `extra_hosts` entry for `host.docker.internal` so the backend in Docker can reach services on the host if needed.
+
+- **frontend/src/App.tsx**
+  - Added a `Callback` route at `/callback` to handle Keycloak’s authorization-code redirect.
+  - Introduced `RedirectCodeToCallback` to automatically route `?code=...` queries on `/` or `/login` to `/callback`.
+  - Wrapped the main `Routes` with this redirect component.
+
+- **frontend/src/api/auth.js**
+  - Repurposed the auth API to be Keycloak-oriented:
+    - Added `getConfig()` to load Keycloak login/register/logout URLs and auth metadata from the backend.
+    - Added `exchangeCodeForTokens()` to call the backend’s `/auth/token` endpoint.
+    - Added `getMe()` and `getMeWithToken()` helpers to fetch the current user with a bearer token.
+  - Removed legacy email/password `signup` and `signin` helpers.
+
+- **frontend/src/api/client.js**
+  - Simplified the response interceptor:
+    - On `401`, it now logs out via `useAuthStore` and redirects to `/login` instead of attempting refresh-token rotation.
+
+- **frontend/src/components/Layout/index.jsx**
+  - Injected `authAPI` and updated the avatar (“M” profile) button behavior:
+    - On click, it clears local auth state, then tries to redirect the browser to the backend-provided Keycloak `logoutUrl` to fully log out.
+    - Falls back to navigating to `/login` if fetching the config fails or no logout URL is available.
+
+- **frontend/src/pages/Login/index.jsx**
+  - Simplified the UI to a single “Sign in with Keycloak” button instead of email/password fields.
+  - On submit, calls `authAPI.getConfig()` and redirects the browser to `config.loginUrl`.
+  - Improved error handling for backend connectivity issues (e.g., backend not running).
+
+- **frontend/src/pages/Signup/index.jsx**
+  - Converted signup to Keycloak registration:
+    - “Sign up with Keycloak” now fetches `config.registerUrl` and redirects there.
+    - Added `useSearchParams` + `useEffect` logic so `/signup?then=register` automatically fetches config and jumps to the Keycloak registration page.
+  - Simplified the form to a single “Sign up with Keycloak” CTA and removed local name/email/password fields.
+  - Updated the legal text to reference “Sign up with Keycloak”.
+
+- **frontend/src/store/authStore.js**
+  - Extended the store with a `setTokens(accessToken, refreshToken)` helper to set tokens without an immediate user object (used in the Keycloak callback flow).
+  - Persisted the new token-only updates to `localStorage` alongside existing auth state.
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from './store/authStore';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+import Callback from './pages/Callback';
 import Dashboard from './pages/Dashboard';
 import MetricConfigs from './pages/MetricConfigs';
 import ApiKeys from './pages/ApiKeys';
@@ -9,6 +10,16 @@ import CodeGeneration from './pages/CodeGeneration';
 import Layout from './components/Layout';
 import { ToastProvider } from './components/ToastContainer';
 import './App.css';
+
+/** If Keycloak redirected to / or /login with ?code=..., send user to /callback so the code is processed. */
+function RedirectCodeToCallback({ children }) {
+  const location = useLocation();
+  const search = location.search || '';
+  if (search.includes('code=') && (location.pathname === '/' || location.pathname === '/login')) {
+    return <Navigate to={'/callback' + search} replace />;
+  }
+  return children;
+}
 
 function PrivateRoute({ children }) {
   const { isAuthenticated } = useAuthStore();
@@ -19,9 +30,11 @@ function App() {
   return (
     <Router>
       <ToastProvider>
+        <RedirectCodeToCallback>
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
+          <Route path="/callback" element={<Callback />} />
           <Route
             path="/"
             element={
@@ -36,6 +49,7 @@ function App() {
             <Route path="code-generation" element={<CodeGeneration />} />
           </Route>
         </Routes>
+        </RedirectCodeToCallback>
       </ToastProvider>
     </Router>
   );

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,20 +1,44 @@
+/**
+ * Keycloak-based auth API.
+ * Login/signup = redirect to Keycloak; callback exchanges code for tokens and fetches /me.
+ */
+import axios from 'axios';
 import client from './client';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+const configBase = `${API_BASE_URL}/api/v1`;
+
 export const authAPI = {
-  signup: async (email, password, name) => {
-    const response = await client.post('/auth/signup', {
-      email,
-      password,
-      name
-    });
-    return response.data;
+  /** Public: get Keycloak login/register URLs and token endpoint for code exchange */
+  getConfig: async () => {
+    const response = await axios.get(`${configBase}/auth/config`);
+    return response.data.data;
   },
 
-  signin: async (email, password) => {
-    const response = await client.post('/auth/signin', {
-      email,
-      password
+  /** Exchange Keycloak authorization code for tokens via backend (avoids CORS with Keycloak). */
+  exchangeCodeForTokens: async (code, redirectUri) => {
+    const response = await axios.post(`${configBase}/auth/token`, { code, redirect_uri: redirectUri });
+    const data = response.data?.data;
+    if (!data?.access_token) throw new Error('No access_token in token response');
+    return {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+      expires_in: data.expires_in,
+      token_type: data.token_type || 'Bearer',
+    };
+  },
+
+  /** Get current user (requires Bearer token in client) */
+  getMe: async () => {
+    const response = await client.get('/auth/me');
+    return response.data.data;
+  },
+
+  /** Get current user with token (use in callback so 401 doesn't trigger client's logout redirect) */
+  getMeWithToken: async (accessToken) => {
+    const response = await axios.get(`${configBase}/auth/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
     });
-    return response.data;
-  }
+    return response.data.data;
+  },
 };

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -24,38 +24,14 @@ client.interceptors.request.use(
   }
 );
 
-// Response interceptor for token refresh
+// Response interceptor: on 401 (Keycloak token expired/invalid), logout and redirect to login
 client.interceptors.response.use(
   (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-
-      try {
-        const { refreshToken, updateToken } = useAuthStore.getState();
-        
-        if (!refreshToken) {
-          throw new Error('No refresh token');
-        }
-
-        const response = await axios.post(`${API_BASE_URL}/api/v1/auth/refresh`, {
-          refreshToken
-        });
-
-        const { accessToken } = response.data.data;
-        updateToken(accessToken);
-
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-        return client(originalRequest);
-      } catch (refreshError) {
-        useAuthStore.getState().logout();
-        window.location.href = '/login';
-        return Promise.reject(refreshError);
-      }
+  (error) => {
+    if (error.response?.status === 401) {
+      useAuthStore.getState().logout();
+      window.location.href = '/login';
     }
-
     return Promise.reject(error);
   }
 );

--- a/frontend/src/components/Layout/index.jsx
+++ b/frontend/src/components/Layout/index.jsx
@@ -2,6 +2,7 @@ import { Outlet, Link, useNavigate, useLocation } from "react-router-dom";
 import { useMemo } from "react";
 import { useAuthStore } from "../../store/authStore";
 import { useThemeStore } from "../../store/themeStore";
+import { authAPI } from "../../api/auth";
 import Logo from "../Logo";
 import { BellIcon, MoonIcon, SunIcon } from "../../assets/icons";
 import "./Layout.css";
@@ -18,8 +19,23 @@ function Layout() {
     return (first ? first : "U").toUpperCase();
   }, [user?.email]);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    // Clear local auth state first
     logout();
+
+    try {
+      // Use backend-provided Keycloak logout URL so we fully log out of Keycloak
+      const config = await authAPI.getConfig();
+      if (config.logoutUrl) {
+        window.location.href = config.logoutUrl;
+        return;
+      }
+    } catch (e) {
+      // If anything fails, fall back to local logout only
+      console.error("Failed to fetch auth config for logout", e);
+    }
+
+    // Fallback: send user back to login screen
     navigate("/login");
   };
 

--- a/frontend/src/pages/Callback/index.jsx
+++ b/frontend/src/pages/Callback/index.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuthStore } from '../../store/authStore';
+import { authAPI } from '../../api/auth';
+import { useToast } from '../../components/ToastContainer';
+import Logo from '../../components/Logo';
+import '../Auth/Auth.css';
+
+function Callback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { setTokens, setAuth } = useAuthStore();
+  const { showToast } = useToast();
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code) {
+      setError('No authorization code received. Please try signing in again.');
+      setLoading(false);
+      return;
+    }
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    const run = async () => {
+      try {
+        const config = await authAPI.getConfig();
+        const redirectUri = config.redirectUri || `${window.location.origin}/callback`;
+        const { access_token, refresh_token } = await authAPI.exchangeCodeForTokens(code, redirectUri);
+        setTokens(access_token, refresh_token);
+        const { user } = await authAPI.getMeWithToken(access_token);
+        setAuth(user, access_token, refresh_token);
+        showToast('Signed in successfully!', 'success', 2000);
+        navigate('/', { replace: true });
+      } catch (err) {
+        const msg =
+          err.response?.data?.error_description ||
+          err.response?.data?.error ||
+          err.response?.data?.message ||
+          err.message ||
+          'Sign-in failed.';
+        setError(msg);
+        showToast(msg, 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    run();
+  }, [searchParams, setTokens, setAuth, navigate, showToast]);
+
+  if (loading) {
+    return (
+      <div className="auth-container">
+        <div className="auth-layout">
+          <div className="auth-card">
+            <div className="auth-logo">
+              <Logo size="large" />
+            </div>
+            <h1>Signing you in…</h1>
+            <p className="auth-subtitle">Completing sign-in with Keycloak</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="auth-container">
+        <div className="auth-layout">
+          <div className="auth-card">
+            <div className="auth-logo">
+              <Logo size="large" />
+            </div>
+            <h1>Sign-in failed</h1>
+            <p className="auth-subtitle">{error}</p>
+            <a href="/login" className="btn btn-primary" style={{ marginTop: '1rem', display: 'inline-block' }}>
+              Back to Sign in
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default Callback;

--- a/frontend/src/pages/Signup/index.jsx
+++ b/frontend/src/pages/Signup/index.jsx
@@ -1,40 +1,47 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useAuthStore } from '../../store/authStore';
+import { useState, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { authAPI } from '../../api/auth';
 import { useToast } from '../../components/ToastContainer';
 import Logo from '../../components/Logo';
-import { ArrowRightIcon, EyeIcon, EyeOffIcon } from '../../assets/icons';
+import { ArrowRightIcon } from '../../assets/icons';
 import '../Auth/Auth.css';
 
 function Signup() {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
+  const [searchParams] = useSearchParams();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
-  const { setAuth } = useAuthStore();
   const { showToast } = useToast();
 
-  const handleSubmit = async (e) => {
+  // After Keycloak logout we land on /signup?then=register; redirect to registration page
+  useEffect(() => {
+    const thenRegister = searchParams.get('then') === 'register';
+    if (!thenRegister) return;
+    let cancelled = false;
+    authAPI
+      .getConfig()
+      .then((config) => {
+        if (!cancelled && config.registerUrl) window.location.href = config.registerUrl;
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [searchParams]);
+
+  const handleSignUp = async (e) => {
     e.preventDefault();
     setError('');
     setLoading(true);
-
     try {
-      const response = await authAPI.signup(email, password, name);
-      const { user, accessToken, refreshToken } = response.data;
-      
-      setAuth(user, accessToken, refreshToken);
-      showToast('Account created successfully! Redirecting...', 'success', 2000);
-      setTimeout(() => navigate('/'), 500);
+      const config = await authAPI.getConfig();
+      // Redirect to Keycloak user registration (enable "User registration" in realm Login settings)
+      window.location.href = config.registerUrl;
     } catch (err) {
-      const errorMsg = err.response?.data?.error || 'Signup failed. Please try again.';
+      const isNetworkError = err.message === 'Network Error' || err.code === 'ERR_NETWORK' || !err.response;
+      const apiUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+      const errorMsg = isNetworkError
+        ? `Cannot connect to the API at ${apiUrl}. Make sure the backend is running.`
+        : (err.response?.data?.message || err.message || 'Could not load sign-up. Try again.');
       setError(errorMsg);
       showToast(errorMsg, 'error');
-    } finally {
       setLoading(false);
     }
   };
@@ -52,64 +59,9 @@ function Signup() {
 
           {error && <div className="error-message">{error}</div>}
 
-          <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label className="form-label">Full Name</label>
-              <input
-                type="text"
-                className="form-input"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="John Doe"
-                disabled={loading}
-                autoComplete="name"
-              />
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Your Email</label>
-              <input
-                type="email"
-                className="form-input"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="jeshika@gmail.com"
-                required
-                disabled={loading}
-                autoComplete="email"
-              />
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Password</label>
-              <div className="input-with-action">
-                <input
-                  type={showPassword ? 'text' : 'password'}
-                  className="form-input"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                  required
-                  minLength={8}
-                  disabled={loading}
-                  autoComplete="new-password"
-                />
-                <button
-                  type="button"
-                  className="input-action"
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  aria-pressed={showPassword}
-                  onClick={() => setShowPassword((v) => !v)}
-                  disabled={loading}
-                >
-                  {showPassword ? <EyeOffIcon size={20} /> : <EyeIcon size={20} />}
-                </button>
-              </div>
-              <small className="form-hint">Must be at least 8 characters with one number.</small>
-            </div>
-
+          <form onSubmit={handleSignUp}>
             <button type="submit" className="btn btn-primary auth-cta" disabled={loading} style={{ width: '100%' }}>
-              <span>{loading ? 'Creating account…' : 'Create Account'}</span>
+              <span>{loading ? 'Redirecting…' : 'Sign up with Keycloak'}</span>
               <ArrowRightIcon size={20} />
             </button>
           </form>
@@ -121,7 +73,7 @@ function Signup() {
         </main>
 
         <div className="auth-terms" aria-label="Terms">
-          By clicking &quot;Create Account&quot;, you agree to our{' '}
+          By clicking &quot;Sign up with Keycloak&quot;, you agree to our{' '}
           <a href="#" onClick={(e) => e.preventDefault()}>
             Terms of Service
           </a>{' '}

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -43,6 +43,18 @@ export const useAuthStore = create((set) => {
       set(newState);
       saveAuth(newState);
     },
+
+    /** Set tokens only (e.g. before fetching /me in callback) */
+    setTokens: (accessToken, refreshToken) => {
+      const newState = {
+        ...useAuthStore.getState(),
+        accessToken,
+        refreshToken,
+        isAuthenticated: !!accessToken
+      };
+      set(newState);
+      saveAuth(newState);
+    },
     
     logout: () => {
       const newState = {


### PR DESCRIPTION
## closes #6 

## Summary
- Replaced local email/password authentication with Keycloak-based SSO, including /auth/config, /auth/token, and /auth/me endpoints.
- Updated frontend login/signup to redirect through Keycloak (including a new /callback handler and avatar-based logout that also logs out of Keycloak).
- Adjusted database, middleware, and Docker Keycloak configuration to support keycloak_sub, JWT validation, and a smoother local dev setup.

**Note:**
-- Existing API endpoints now rely on Keycloak JWT via the new authenticate middleware.
-- User registration must be enabled in Keycloak for signup to work end to end.
## More to do:
UI modification through making customized Keycloak theme is  still left out to be completed along with directly redirecting to Sign Up/ Sign In  page and integrating in Typescript.
## Glimpses
<img width="2474" height="1218" alt="image" src="https://github.com/user-attachments/assets/6f4a445b-a815-4166-addd-36b0989ce712" />
<img width="2474" height="1218" alt="image" src="https://github.com/user-attachments/assets/53fabcc8-fbd4-40ef-9b21-2771c49379ce" />
<img width="2474" height="1218" alt="image" src="https://github.com/user-attachments/assets/1f78ec52-85a6-4713-bfb3-6df323993f54" />


