### PR TITLE
Feat: Integrating Grafana within Dashboard

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -63,6 +63,11 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      # Enable iframe embedding in frontend
+      - GF_SECURITY_ALLOW_EMBEDDING=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_SECURITY_COOKIE_SAMESITE=disabled
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning

--- a/frontend/src/components/GrafanaEmbed/GrafanaEmbed.css
+++ b/frontend/src/components/GrafanaEmbed/GrafanaEmbed.css
@@ -1,0 +1,71 @@
+/* GrafanaEmbed Component Styles */
+.grafana-embed {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--bg-primary);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
+}
+
+[data-theme='dark'] .grafana-embed {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.grafana-embed__iframe {
+  display: block;
+  border: none;
+  transition: opacity 0.3s ease;
+}
+
+.grafana-embed__iframe--loading {
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.grafana-embed__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+}
+
+.grafana-embed__error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.grafana-embed__error-content {
+  text-align: center;
+  padding: 2rem;
+}
+
+.grafana-embed__error-icon {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.grafana-embed__error-content p {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.grafana-embed__error-link {
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 0.875rem;
+  text-decoration: none;
+}
+
+.grafana-embed__error-link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/components/GrafanaEmbed/index.jsx
+++ b/frontend/src/components/GrafanaEmbed/index.jsx
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react';
+import { Skeleton } from '@/components/Skeleton';
+import './GrafanaEmbed.css';
+
+/**
+ * GrafanaEmbed - Embeds Grafana dashboards or panels via iframe
+ * 
+ * @param {string} dashboardUid - The unique identifier of the Grafana dashboard
+ * @param {number} panelId - Optional panel ID to embed a specific panel (uses d-solo endpoint)
+ * @param {string} from - Time range start (default: 'now-1h')
+ * @param {string} to - Time range end (default: 'now')
+ * @param {string} refresh - Auto-refresh interval (default: '10s')
+ * @param {string} theme - Grafana theme: 'light' or 'dark' (default: follows system)
+ * @param {number} height - iframe height in pixels (default: 400)
+ * @param {string} title - Accessible title for the iframe
+ * @param {boolean} kiosk - Enable kiosk mode for full dashboard (default: true)
+ */
+function GrafanaEmbed({
+  dashboardUid,
+  panelId,
+  from = 'now-1h',
+  to = 'now',
+  refresh = '10s',
+  theme,
+  height = 400,
+  title = 'Metrics Dashboard',
+  kiosk = true,
+}) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const grafanaUrl = import.meta.env.VITE_GRAFANA_URL || 'http://localhost:3001';
+
+  // Build the embed URL
+  const buildEmbedUrl = () => {
+    const params = new URLSearchParams({
+      from,
+      to,
+      refresh,
+      ...(theme && { theme }),
+    });
+
+    if (panelId) {
+      // Embed a single panel
+      return `${grafanaUrl}/d-solo/${dashboardUid}?panelId=${panelId}&${params.toString()}`;
+    }
+
+    // Embed full dashboard with optional kiosk mode
+    const kioskParam = kiosk ? '&kiosk=tv' : '';
+    return `${grafanaUrl}/d/${dashboardUid}?${params.toString()}${kioskParam}`;
+  };
+
+  const embedUrl = buildEmbedUrl();
+
+  const handleLoad = () => {
+    setIsLoading(false);
+  };
+
+  const handleError = () => {
+    setIsLoading(false);
+    setHasError(true);
+  };
+
+  // Reset loading state when URL changes
+  useEffect(() => {
+    setIsLoading(true);
+    setHasError(false);
+  }, [embedUrl]);
+
+  return (
+    <div className="grafana-embed">
+      {isLoading && (
+        <div className="grafana-embed__loading" style={{ height }}>
+          <Skeleton width="100%" height="100%" />
+        </div>
+      )}
+
+      {hasError && (
+        <div className="grafana-embed__error" style={{ height }}>
+          <div className="grafana-embed__error-content">
+            <svg
+              className="grafana-embed__error-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p>Unable to load Grafana dashboard</p>
+            <a
+              href={grafanaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="grafana-embed__error-link"
+            >
+              Open Grafana directly →
+            </a>
+          </div>
+        </div>
+      )}
+
+      <iframe
+        src={embedUrl}
+        width="100%"
+        height={height}
+        frameBorder="0"
+        title={title}
+        onLoad={handleLoad}
+        onError={handleError}
+        className={`grafana-embed__iframe ${isLoading ? 'grafana-embed__iframe--loading' : ''}`}
+        allow="fullscreen"
+      />
+    </div>
+  );
+}
+
+export { GrafanaEmbed };
+export default GrafanaEmbed;

--- a/frontend/src/pages/Dashboard/Dashboard.css
+++ b/frontend/src/pages/Dashboard/Dashboard.css
@@ -321,6 +321,75 @@
   color: #4ade80;
 }
 
+/* Metrics Visualization Section */
+.metrics-visualization {
+  margin-top: 3rem;
+  background: var(--bg-primary);
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+[data-theme='dark'] .metrics-visualization {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.metrics-visualization__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.metrics-visualization__header h2 {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+}
+
+.metrics-visualization__subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9375rem;
+}
+
+.metrics-visualization__link {
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 0.875rem;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.metrics-visualization__link:hover {
+  text-decoration: underline;
+}
+
+.metrics-visualization__container {
+  margin-bottom: 1rem;
+}
+
+.metrics-visualization__hint {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+  opacity: 0.8;
+}
+
+@media (max-width: 640px) {
+  .metrics-visualization__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .metrics-visualization {
+    padding: 1.5rem;
+  }
+}
+
 .dashboard-footer {
   margin-top: 2rem;
   display: flex;

--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -4,6 +4,7 @@ import { metricConfigsAPI } from '@/api/metricConfigs';
 import { apiKeysAPI } from '@/api/apiKeys';
 import { AnalyticsIcon, DocumentIcon, KeyIcon, PlusIcon, TrendUpIcon } from '@/assets/icons';
 import { Skeleton } from '@/components/Skeleton';
+import { GrafanaEmbed } from '@/components/GrafanaEmbed';
 import './Dashboard.css';
 
 function Dashboard() {
@@ -173,6 +174,42 @@ function Dashboard() {
             </div>
           </div>
         </div>
+      </section>
+
+      {/* Live Metrics Visualization Section */}
+      <section className="metrics-visualization">
+        <div className="metrics-visualization__header">
+          <div>
+            <h2>Live Metrics</h2>
+            <p className="metrics-visualization__subtitle">
+              Real-time telemetry data from your connected applications
+            </p>
+          </div>
+          <a
+            href={grafanaUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="metrics-visualization__link"
+          >
+            Open Full Dashboard →
+          </a>
+        </div>
+
+        <div className="metrics-visualization__container">
+          <GrafanaEmbed
+            dashboardUid="metrics"
+            from="now-1h"
+            to="now"
+            refresh="10s"
+            height={450}
+            title="Vizme Metrics Dashboard"
+            kiosk={true}
+          />
+        </div>
+
+        <p className="metrics-visualization__hint">
+          Not seeing data? Make sure you have configured metrics and integrated the tracking code.
+        </p>
       </section>
 
       <footer className="dashboard-footer">


### PR DESCRIPTION
## Summary

This PR integrates **Grafana dashboard visualization** directly within the **Vizme Dashboard**, enabling users to view **real-time telemetry metrics** without leaving the application.

## Why?
We don't want our client to switch between the tabs while analyzing their metrics. So, we will have the analyzing dashboard within our own dashboard. 

## Glimpse of Feature

https://github.com/user-attachments/assets/fb960b07-af94-42dc-acb5-076fa9d3545a

---

closes #66 