### PR TITLE
Enhancement: UI api_key page

### DIFF
--- a/backend/src/routes/codeGeneration.routes.js
+++ b/backend/src/routes/codeGeneration.routes.js
@@ -20,7 +20,7 @@ router.use(apiLimiter);
  */
 router.post('/',
   [
-    body('metric_config_id').optional().isInt(),
+    body('metric_config_id').optional({ nullable: true }).isInt().withMessage('metric_config_id must be an integer'),
     body('api_key_id').isInt().withMessage('API key ID is required'),
     body('auto_track').optional().isBoolean(),
     body('custom_events').optional().isBoolean()

--- a/frontend/src/api/apiKeys.js
+++ b/frontend/src/api/apiKeys.js
@@ -1,15 +1,39 @@
 import client from './client';
 
 export const apiKeysAPI = {
+  /** Fetch all keys for the authenticated user (keys are masked — no raw values). */
   getAll: async () => {
     const response = await client.get('/api-keys');
     return response.data;
   },
 
+  /** Manually create a new API key. Raw key is in the response for one-time clipboard copy. */
   create: async (keyName) => {
     const response = await client.post('/api-keys', {
       key_name: keyName,
     });
+    return response.data;
+  },
+
+  /**
+   * Idempotent ensure — returns the existing key (masked) or creates a new one.
+   * When `is_new` is true the response contains `data.api_key` for one-time copy.
+   *
+   * @param {number|null} metricConfigId - optional metric config to scope the key to
+   */
+  ensure: async (metricConfigId = null) => {
+    const response = await client.post('/api-keys/ensure', {
+      metric_config_id: metricConfigId,
+    });
+    return response.data;
+  },
+
+  /**
+   * Retrieve the raw API key for clipboard copy only.
+   * The frontend must NEVER render this value — use it only with navigator.clipboard.
+   */
+  copy: async (id) => {
+    const response = await client.post(`/api-keys/${id}/copy`);
     return response.data;
   },
 

--- a/frontend/src/api/codeGeneration.js
+++ b/frontend/src/api/codeGeneration.js
@@ -2,12 +2,19 @@ import client from './client';
 
 export const codeGenerationAPI = {
   generate: async (apiKeyId, metricConfigId, options = {}) => {
-    const response = await client.post('/code-generation', {
+    const body = {
       api_key_id: apiKeyId,
-      metric_config_id: metricConfigId,
       auto_track: options.autoTrack !== false,
       custom_events: options.customEvents !== false,
-    });
+    };
+
+    // Only include metric_config_id when it is a real integer — avoids
+    // sending `null` which express-validator's optional() can reject.
+    if (metricConfigId != null) {
+      body.metric_config_id = metricConfigId;
+    }
+
+    const response = await client.post('/code-generation', body);
     return response.data;
   },
 };

--- a/frontend/src/pages/ApiKeys/ApiKeys.css
+++ b/frontend/src/pages/ApiKeys/ApiKeys.css
@@ -560,6 +560,34 @@
   text-align: right;
 }
 
+.key-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn-copy-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  background: transparent;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-copy-inline:hover {
+  background: rgba(99, 102, 241, 0.08);
+  border-color: rgba(99, 102, 241, 0.25);
+  color: var(--text-primary);
+}
+
 .btn-revoke {
   padding: 0.375rem 0.75rem;
   background: transparent;

--- a/frontend/src/pages/CodeGeneration/index.jsx
+++ b/frontend/src/pages/CodeGeneration/index.jsx
@@ -53,7 +53,8 @@ function CodeGeneration() {
       ]);
 
       const keys = keysRes.data || [];
-      const configs = configsRes.data || [];
+      // metricConfigsAPI.getAll() returns an unwrapped array, not { data: [] }
+      const configs = Array.isArray(configsRes) ? configsRes : (configsRes?.data || []);
 
       setApiKeys(keys);
       setMetricConfigs(configs);
@@ -112,7 +113,7 @@ function CodeGeneration() {
 
   // Fallback snippet template if backend is unavailable
   const getFallbackSnippet = () => {
-    const appId = selectedApiKey?.api_key?.substring(0, 20) || 'vz_your_api_key';
+    const appId = selectedApiKey?.masked_key || 'vz_your_api_key';
     return `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'start':Date.now()});var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='http://localhost:3000/api/v1/tracker.js?k=${encodeURIComponent(appId)}&a=${autoPageViews ? '1' : '0'}&c=1';f.parentNode.insertBefore(j,f);})(window,document,'script','metricsTracker');`;
   };
 


### PR DESCRIPTION
## Enhance API Key Management — Secure-by-Default Key Handling

### Summary

highlights about API key management system to follow security best practices: raw API keys are **never** stored in frontend state or rendered in the DOM. Keys are masked server-side, and a dedicated secure-copy endpoint allows clipboard access without exposing secrets in the UI.

### Why?

Previously, raw API keys were returned in list responses and displayed directly in the browser. This created unnecessary exposure risk — keys could leak via DOM inspection, browser extensions, or screen captures. This PR ensures keys are only accessible ephemerally through a controlled copy-to-clipboard flow.

### Security Considerations

- Raw API keys are **never** included in `GET /` list responses
- Raw key is returned **once** on creation (via `POST /ensure` or `POST /`), then only accessible through the `POST /:id/copy` endpoint
- Frontend never persists raw keys in component state or renders them in the DOM
- Unique partial index prevents duplicate keys per user/metric-config pair
- Race condition on concurrent `POST /ensure` is handled gracefully via constraint violation fallback

### Test Plan

- [ ] Verify `GET /api-keys` returns `masked_key` and **not** `api_key`
- [ ] Verify `POST /api-keys/ensure` creates a new key and returns the raw key on first call
- [ ] Verify `POST /api-keys/ensure` returns the existing masked key on subsequent calls (idempotent)
- [ ] Verify `POST /api-keys/:id/copy` returns the raw key for the authenticated user only
- [ ] Verify `POST /api-keys/:id/copy` returns 404 for another user's key
- [ ] Verify the hero panel displays only masked keys after page load
- [ ] Verify the Copy button triggers clipboard write and shows check icon feedback
- [ ] Verify revoking the active key clears the hero panel
- [ ] Verify the Code Generation page correctly handles metric config response shape
- [ ] Verify database migration adds `metric_config_id` column and unique index without errors on re-run (idempotent)

### Glimpse of feature
<img width="1440" height="783" alt="Screenshot 2026-02-10 at 1 01 20 PM" src="https://github.com/user-attachments/assets/afdc8045-864e-44d4-ad86-1fc241fbfbd8" />
