### PR TITLE
refactor: metrics servics

### DIFF
--- a/backend/src/services/metrics.service.js
+++ b/backend/src/services/metrics.service.js
@@ -54,80 +54,57 @@ const hashLabels = (labels) => {
  * @param {Object} labels - Metric labels
  * @returns {Counter|Gauge|Histogram|Summary} - Prometheus metric instance
  */
-const getOrCreateMetric = (userId, metricName, metricType, labels) => {
-    // Create labels with user_id included
-    const metricLabels = {
-      ...labels,
-      user_id: userId.toString()
-    };
+const getOrCreateMetric = (metricName, metricType, labelKeys) => {
+  // Cache by metric name + sorted label key names (not values, not userId)
+  const allLabelNames = [...labelKeys, 'user_id'].sort();
+  const key = `${metricName}_${allLabelNames.join(',')}`;
 
-  const labelHash = hashLabels(metricLabels);
-  const key = `${userId}_${metricName}_${labelHash}`;
-
-  // Return existing instance if available
   if (metricInstances.has(key)) {
     return metricInstances.get(key);
   }
 
-  const fullMetricName = `user_metric_${metricName}`;
-  
-  // Check if metric already exists in registry
-  const existingMetric = register.getSingleMetric(fullMetricName);
-  
-  if (existingMetric) {
-    // Metric exists - reuse it (prom-client allows different label combinations on same metric)
-    // Just cache this instance for this label combination
-    metricInstances.set(key, existingMetric);
-    return existingMetric;
-  }
-  // Create appropriate metric type
   let metric;
-  const labelNames = Object.keys(metricLabels).sort(); // Sort for consistency
+  const fullMetricName = `user_metric_${metricName}`;
 
   switch (metricType.toLowerCase()) {
     case 'counter':
       metric = new Counter({
         name: fullMetricName,
         help: `Counter metric: ${metricName}`,
-        labelNames: labelNames,
+        labelNames: allLabelNames,
         registers: [register]
       });
       break;
-
     case 'gauge':
       metric = new Gauge({
         name: fullMetricName,
         help: `Gauge metric: ${metricName}`,
-        labelNames: labelNames,
+        labelNames: allLabelNames,
         registers: [register]
       });
       break;
-
     case 'histogram':
       metric = new Histogram({
         name: fullMetricName,
         help: `Histogram metric: ${metricName}`,
-        labelNames: Object.keys(metricLabels),
-        buckets: [0.1, 0.5, 1, 2.5, 5, 10, 25, 50, 100], // Default buckets
+        labelNames: allLabelNames,
+        buckets: [0.1, 0.5, 1, 2.5, 5, 10, 25, 50, 100],
         registers: [register]
       });
       break;
-
     case 'summary':
       metric = new Summary({
         name: fullMetricName,
         help: `Summary metric: ${metricName}`,
-        labelNames: Object.keys(metricLabels),
-        percentiles: [0.01, 0.1, 0.5, 0.9, 0.99], // Default percentiles
+        labelNames: allLabelNames,
+        percentiles: [0.01, 0.1, 0.5, 0.9, 0.99],
         registers: [register]
       });
       break;
-
     default:
       throw new Error(`Unsupported metric type: ${metricType}`);
   }
 
-  // Cache the instance
   metricInstances.set(key, metric);
   return metric;
 };
@@ -157,7 +134,7 @@ export const recordMetric = (metricData, userId) => {
   }
 
   // Get or create the metric instance
-  const metric = getOrCreateMetric(userId, name, type, labels);
+  const metric = getOrCreateMetric(name, type, Object.keys(labels));
 
   // Prepare labels with user_id
   const metricLabels = {


### PR DESCRIPTION
## Fix: Resolve multi-tenancy metric registration collision in metrics service

### Summary
- Fixed a bug where the second user submitting a metric with the same name would cause a `prom-client` registration error, because metric instances were cached per-user but Prometheus only allows one metric object per name per registry.
- Changed `getOrCreateMetric` to cache by metric name + label key names (excluding `userId` and label values), so all users share the same `prom-client` instance and are differentiated by the `user_id` label value instead.

### Problem
The `metricInstances` cache key included the `userId` (`${userId}_${metricName}_${labelHash}`), but the Prometheus metric name did not (`user_metric_${metricName}`). This meant:
1. User A creates `user_metric_request_count` — succeeds and is cached under `userA_request_count_...`
2. User B submits the same metric — cache miss (different key `userB_request_count_...`) — tries to register a **new** metric with the same name — **prom-client throws**

### Fix
- Removed `userId` from the `metricInstances` cache key so all users share a single `prom-client` metric instance per metric name.
- `user_id` remains as a Prometheus label, which is the idiomatic way to handle multi-tenancy — users are distinguished by label values, not by separate metric objects.
- The debug `metricsStore` still uses `userId` in its key, which is fine since it's not part of the Prometheus registry.

### Test plan
- [ ] Verify User A can submit a metric (e.g., `request_count` counter) successfully
- [ ] Verify User B can submit a metric with the **same name** without getting a registration error
- [ ] Verify Prometheus `/metrics` output contains both users' data distinguished by `user_id` label
- [ ] Verify `clearUserMetrics` still correctly clears only the target user's data from the debug store
- [ ] Verify existing metric types (counter, gauge, histogram, summary) all work correctly after the change

closes #82