### PR TITLE
feat: Add Keycloak infrastructure setup (Auth Migration Step 1)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,68 @@ services:
     profiles:
       - local-db # Only start with: docker compose --profile local-db up
 
+  # ============================================================
+  # One-shot init container — creates the "keycloak" schema in
+  # the cloud PostgreSQL if it doesn't already exist.
+  # ============================================================
+  keycloak-db-init:
+    image: postgres:15-alpine
+    container_name: metrics_keycloak_db_init
+    command: >
+      sh -c "PGPASSWORD=$$DB_PASSWORD psql
+      -h $$DB_HOST -p $${DB_PORT:-5432} -U $$DB_USER -d $$DB_NAME
+      -c 'CREATE SCHEMA IF NOT EXISTS keycloak;'"
+    env_file:
+      - .env
+    networks:
+      - metrics_network
+    restart: "no"
+
+  # ============================================================
+  # Keycloak AAA — Identity Provider
+  # Uses the same cloud PostgreSQL as the app, but in a separate
+  # schema ("keycloak") to keep tables isolated from app tables.
+  # ============================================================
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    container_name: metrics_keycloak
+    command: start-dev --import-realm
+    environment:
+      # Keycloak admin credentials
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      # Database connection — same cloud PostgreSQL, separate schema
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://${DB_HOST}:${DB_PORT:-5432}/${DB_NAME}?sslmode=require
+      KC_DB_USERNAME: ${DB_USER}
+      KC_DB_PASSWORD: ${DB_PASSWORD}
+      KC_DB_SCHEMA: keycloak
+      # Server config
+      KC_HTTP_PORT: 8080
+      KC_HOSTNAME_STRICT: "false"
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTP_ENABLED: "true"
+      # Health
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '\"status\":\"UP\"'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    depends_on:
+      keycloak-db-init:
+        condition: service_completed_successfully
+    networks:
+      - metrics_network
+    restart: unless-stopped
+
   # ... (prometheus, pushgateway, grafana stay the same) ...
   prometheus:
     image: prom/prometheus:latest
@@ -102,6 +164,12 @@ services:
       - GRAFANA_URL=${GRAFANA_URL:-http://localhost:3001}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - API_BASE_URL=${API_BASE_URL:-http://localhost:3000}
+      # Keycloak config (for future backend token validation)
+      - AUTH_PROVIDER=${AUTH_PROVIDER:-legacy}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-unified-visibility}
+      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-uv-backend}
+      - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-}
     volumes:
       - ../backend:/app
       - /app/node_modules
@@ -131,7 +199,7 @@ volumes:
   postgres_data:
   prometheus_data:
   pushgateway_data:
-  grafana_data:
+  grafana_data: 
 
 networks:
   metrics_network:

--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -1,0 +1,159 @@
+{
+  "id": "unified-visibility",
+  "realm": "unified-visibility",
+  "displayName": "Unified Visibility Platform",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 5,
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "Default user role",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "admin",
+        "description": "Administrator role",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "defaultRoles": ["user"],
+  "requiredCredentials": ["password"],
+  "passwordPolicy": "length(8)",
+  "clients": [
+    {
+      "clientId": "uv-frontend",
+      "name": "Unified Visibility Frontend",
+      "description": "Public OIDC client for the React SPA frontend",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "rootUrl": "http://localhost:5173",
+      "baseUrl": "/",
+      "redirectUris": [
+        "http://localhost:5173/*",
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173",
+        "http://localhost:3000"
+      ],
+      "adminUrl": "http://localhost:5173",
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:5173/*",
+        "pkce.code.challenge.method": "S256",
+        "access.token.lifespan": "900",
+        "client.session.idle.timeout": "1800"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "clientId": "uv-backend",
+      "name": "Unified Visibility Backend",
+      "description": "Confidential OIDC client for backend token validation",
+      "enabled": true,
+      "publicClient": false,
+      "directAccessGrantsEnabled": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": true,
+      "bearerOnly": false,
+      "protocol": "openid-connect",
+      "secret": "uv-backend-dev-secret",
+      "attributes": {
+        "use.refresh.tokens": "true"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "scopeMappings": [
+    {
+      "client": "uv-frontend",
+      "roles": ["user"]
+    }
+  ],
+  "accessTokenLifespan": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "offlineSessionIdleTimeout": 2592000,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "smtpServer": {},
+  "loginTheme": "keycloak",
+  "accountTheme": "keycloak.v2",
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials"
+}

--- a/docs/keycloak-auth-step-1.md
+++ b/docs/keycloak-auth-step-1.md
@@ -1,0 +1,309 @@
+# Step 1 — Keycloak Infrastructure Setup
+
+**Date**: 2026-02-11
+**Branch**: `auth-branch`
+**Status**: Complete — Awaiting approval
+
+---
+
+## 1. What Changed
+
+### Files Modified
+| File | Change |
+|------|--------|
+| `docker/docker-compose.yml` | Added `keycloak-db` and `keycloak` services; added `keycloak_postgres_data` volume; added Keycloak env vars to `backend` service |
+
+### Files Created
+| File | Purpose |
+|------|---------|
+| `docker/keycloak/realm-export.json` | Pre-configured Keycloak realm with OIDC clients |
+| `docs/keycloak-auth-step-1.md` | This documentation |
+
+### No Application Code Changed
+- Backend code: **untouched**
+- Frontend code: **untouched**
+- Database schema: **untouched**
+- Existing auth flow: **untouched**
+
+---
+
+## 2. Architecture Diagram
+
+```
+                         YOUR CLOUD POSTGRESQL (single database)
+                    ┌──────────────────────────────────────────────┐
+                    │                                              │
+                    │  "public" schema         "keycloak" schema   │
+                    │  (app tables)            (Keycloak tables)   │
+                    │  ────────────            ─────────────────   │
+                    │  users                   realm               │
+                    │  api_keys                client              │
+                    │  metric_configs          user_entity         │
+                    │  refresh_tokens          credential          │
+                    │                          ...                 │
+                    └──────────┬──────────────────────┬────────────┘
+                               │                      │
+                               │ pg driver            │ JDBC
+                               │                      │
+┌──────────────────────────────┼──────────────────────┼────────────┐
+│              Docker Compose  │                      │            │
+│                              │                      │            │
+│                      ┌───────┴──────┐        ┌──────┴───────┐   │
+│                      │   backend    │        │  keycloak    │   │
+│                      │  :3000       │        │  :8080       │   │
+│                      │              │        │              │   │
+│                      │ AUTH_PROVIDER│        │  Realm:      │   │
+│                      │ = legacy     │        │  unified-    │   │
+│                      └──────────────┘        │  visibility  │   │
+│                             ▲                └──────────────┘   │
+│                             │                                    │
+│                      ┌──────┴──────┐   ┌──────────────┐        │
+│                      │ prometheus  │   │   grafana    │        │
+│                      │ :9090       │   │   :3001      │        │
+│                      └─────────────┘   └──────────────┘        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Key point**: Both the backend and Keycloak connect to the **same cloud PostgreSQL**, but they use **separate schemas** — app tables live in `public`, Keycloak tables live in `keycloak`. They cannot interfere with each other. The `AUTH_PROVIDER` is set to `legacy` — the backend still uses the existing JWT auth. Keycloak is running but not yet integrated.
+
+---
+
+## 3. Configuration Explanation
+
+### 3.1 Docker Services Added
+
+#### `keycloak` (Identity Provider)
+- **Image**: `quay.io/keycloak/keycloak:26.0` (latest stable)
+- **Command**: `start-dev --import-realm` (dev mode + auto-imports realm config on first boot)
+- **Port**: `8080` (Keycloak admin console and OIDC endpoints)
+- **Database**: Uses the **same cloud PostgreSQL** as the app, but with `KC_DB_SCHEMA=keycloak` to store all Keycloak tables in a separate `keycloak` schema — keeping them fully isolated from app tables (`users`, `api_keys`, etc. live in the default `public` schema)
+- **Health check**: HTTP check on `/health/ready`
+- **Realm import**: Mounts `./keycloak/realm-export.json` for automatic setup
+- **env_file**: Loads `.env` to pick up `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+
+### 3.2 Realm Configuration (`realm-export.json`)
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| **Realm name** | `unified-visibility` | Matches your project name |
+| **Registration allowed** | `true` | Users can self-register via Keycloak |
+| **Email as username** | `true` | Matches your current email-based login |
+| **Password policy** | `length(8)` | Matches your current 8-char minimum |
+| **Brute force protection** | Enabled, 5 failures | Similar to your current `authLimiter` (5 req/min) |
+| **Access token lifespan** | 900s (15 min) | Matches your current `JWT_ACCESS_EXPIRY` default |
+| **SSO session idle** | 1800s (30 min) | Reasonable idle timeout |
+
+### 3.3 OIDC Clients Configured
+
+#### `uv-frontend` (Public Client — for React SPA)
+| Setting | Value | Reason |
+|---------|-------|--------|
+| **Type** | Public (no secret) | SPAs cannot securely store secrets |
+| **Flow** | Authorization Code + PKCE (S256) | Industry standard for SPAs |
+| **Direct Access Grants** | Enabled | Allows password-based login for testing |
+| **Redirect URIs** | `http://localhost:5173/*` | Your Vite dev server |
+| **Web Origins** | `http://localhost:5173`, `http://localhost:3000` | CORS allowlist |
+| **Token lifespan** | 900s (15 min) | Matches existing access token expiry |
+
+#### `uv-backend` (Confidential Client — for token validation)
+| Setting | Value | Reason |
+|---------|-------|--------|
+| **Type** | Confidential (has secret) | Backend can securely store secrets |
+| **Flow** | Service accounts only | Backend validates tokens, doesn't initiate login |
+| **Secret** | `uv-backend-dev-secret` | Dev-only; change in production |
+| **Bearer Only** | false | Can also use service account for admin API calls |
+
+### 3.4 Roles Configured
+| Role | Purpose |
+|------|---------|
+| `user` | Default role assigned to all registered users |
+| `admin` | Administrator role (for future authorization phase) |
+
+### 3.5 Backend Environment Variables Added
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `AUTH_PROVIDER` | `legacy` | Currently set to `legacy` — no behavioral change |
+| `KEYCLOAK_URL` | `http://keycloak:8080` | Internal Docker URL for backend-to-Keycloak |
+| `KEYCLOAK_REALM` | `unified-visibility` | Realm name |
+| `KEYCLOAK_CLIENT_ID` | `uv-backend` | Backend client ID |
+| `KEYCLOAK_CLIENT_SECRET` | (empty) | Will be set in Step 2 |
+
+---
+
+## 4. Security Implications
+
+| Concern | Assessment |
+|---------|-----------|
+| **Existing auth unaffected** | `AUTH_PROVIDER=legacy` means backend ignores Keycloak entirely |
+| **Keycloak admin console exposed** | Port 8080 — dev mode only. In production, use HTTPS + strong admin password |
+| **Default admin credentials** | `admin/admin` — must be changed for production |
+| **Backend client secret** | `uv-backend-dev-secret` — dev only, will be rotated |
+| **Schema isolation** | Keycloak uses `keycloak` schema in cloud DB; app uses `public` schema — no table conflicts |
+| **Network exposure** | Keycloak is on same Docker network but not connected to any app service yet |
+
+---
+
+## 5. Testing Instructions
+
+### 5.1 Prerequisites
+- Docker and Docker Compose installed
+- Your existing `docker/.env` file with cloud DB credentials
+
+### 5.2 Start the Services
+
+```bash
+# From the docker/ directory
+cd docker/
+
+# Start all services (Keycloak + existing services)
+docker compose up -d
+
+# Watch Keycloak startup (takes 30-60 seconds on first boot)
+docker compose logs -f keycloak
+```
+
+Wait until you see:
+```
+Keycloak ... started in Xs
+```
+
+### 5.3 Test Cases
+
+#### Test 1: Keycloak Admin Console Accessible
+1. Open browser: `http://localhost:8080`
+2. Click "Administration Console"
+3. Login with `admin` / `admin`
+4. **Expected**: You see the Keycloak admin dashboard
+
+#### Test 2: Realm Was Imported
+1. In admin console, click the realm dropdown (top-left, says "Keycloak" or "master")
+2. **Expected**: You see `unified-visibility` realm listed
+3. Select it
+4. **Expected**: Realm dashboard shows "Unified Visibility Platform"
+
+#### Test 3: Clients Were Created
+1. Navigate to: Clients (left sidebar)
+2. **Expected**: You see `uv-frontend` and `uv-backend` in the clients list
+3. Click `uv-frontend`
+4. **Expected**: Public client, redirect URIs include `http://localhost:5173/*`
+5. Click `uv-backend`
+6. **Expected**: Confidential client with credentials tab showing the secret
+
+#### Test 4: OIDC Discovery Endpoint Works
+```bash
+curl -s http://localhost:8080/realms/unified-visibility/.well-known/openid-configuration | head -20
+```
+**Expected**: JSON with `authorization_endpoint`, `token_endpoint`, `jwks_uri`, etc.
+
+#### Test 5: Existing Application Still Works
+1. Your backend at `http://localhost:3000/health` should still return healthy
+2. Frontend at `http://localhost:5173` should still load and login should work as before
+3. Prometheus at `http://localhost:9090` should still be scraping
+4. Grafana at `http://localhost:3001` should still work
+
+**This is the most important test** — Keycloak's addition must not break anything.
+
+#### Test 6: Keycloak Schema is Separate from App Schema
+```bash
+# Connect to your cloud DB and list schemas
+# You should see both "public" (app) and "keycloak" (Keycloak) schemas
+# The Keycloak tables live only inside the "keycloak" schema
+
+# List Keycloak tables (should show realm, client, user_entity, etc.)
+# Use your cloud DB connection tool or psql:
+# psql -h <DB_HOST> -U <DB_USER> -d <DB_NAME> -c "\dt keycloak.*"
+
+# List app tables (should show users, api_keys, metric_configs, etc.)
+# psql -h <DB_HOST> -U <DB_USER> -d <DB_NAME> -c "\dt public.*"
+```
+
+### 5.4 Quick Verification Commands
+
+```bash
+# Check all containers are running
+docker compose ps
+
+# Expected output should show:
+#   metrics_keycloak   — running (healthy)  
+#   metrics_backend    — running (healthy)
+#   metrics_prometheus — running
+#   metrics_grafana    — running
+
+# Check Keycloak health
+curl -s http://localhost:8080/health/ready
+
+# Expected: {"status":"UP","checks":[...]}
+```
+
+### 5.5 Failure Scenarios
+
+| Scenario | Symptom | Fix |
+|----------|---------|-----|
+| Port 8080 already in use | Keycloak fails to start | Change port mapping in docker-compose: `"8081:8080"` |
+| Realm not imported | No `unified-visibility` realm | Delete keycloak volume: `docker volume rm docker_keycloak_postgres_data`, then restart |
+| Keycloak slow to start | Health check fails initially | Normal — first boot takes 60-90s. `start_period: 60s` accounts for this |
+| Backend can't reach cloud DB | Backend health fails | Unrelated to Keycloak — check your `.env` DB credentials |
+| Out of memory | Containers crash | Keycloak needs ~512MB. Ensure system has enough free RAM |
+
+### 5.6 Rollback Steps
+
+To completely remove Keycloak (zero impact on application):
+
+```bash
+# Stop Keycloak
+docker compose stop keycloak
+
+# Remove container
+docker compose rm -f keycloak
+
+# (Optional) Drop Keycloak schema from cloud DB to clean up tables
+# psql -h <DB_HOST> -U <DB_USER> -d <DB_NAME> -c "DROP SCHEMA keycloak CASCADE;"
+```
+
+To fully revert:
+1. `git checkout docker/docker-compose.yml` — restores original compose file
+2. `rm -rf docker/keycloak/` — removes realm config directory
+3. `docker compose up -d` — restart without Keycloak
+4. (Optional) Drop the `keycloak` schema from cloud DB if you want to remove Keycloak's tables
+
+---
+
+## 6. Verification Checklist
+
+- [ ] `docker compose up -d` succeeds with no errors
+- [ ] `metrics_keycloak` container is running and healthy
+- [ ] Keycloak admin console accessible at `http://localhost:8080`
+- [ ] Admin login works with `admin` / `admin`
+- [ ] `unified-visibility` realm exists
+- [ ] `uv-frontend` client exists (public, redirect to localhost:5173)
+- [ ] `uv-backend` client exists (confidential, has secret)
+- [ ] OIDC discovery endpoint returns valid JSON
+- [ ] Existing backend still healthy (`http://localhost:3000/health`)
+- [ ] Existing frontend still loads and login works
+- [ ] Existing Prometheus still scraping
+- [ ] Existing Grafana still accessible
+- [ ] Cloud DB has `keycloak` schema with Keycloak tables
+- [ ] Cloud DB `public` schema (app tables) is untouched
+
+---
+
+## 7. What Was NOT Changed
+
+- **No application code** was modified (backend or frontend)
+- **No database schema** changes to your cloud PostgreSQL
+- **No existing auth behavior** changed (`AUTH_PROVIDER=legacy`)
+- **No API contracts** changed
+- **No UI changes**
+- **No dependency changes** in `package.json` files
+
+---
+
+**STEP 1 COMPLETE — Awaiting approval to continue.**
+
+**Next recommended step**: Step 2 — Backend Dual Token Validation
+- Install JWKS/OIDC token verification library
+- Create `keycloak.middleware.js` for Keycloak token validation
+- Wrap `authenticate` middleware with dual-auth logic (Keycloak OR legacy JWT)
+- Add `keycloak_id` mapping column to `users` table on cloud DB
+- Feature flag: `AUTH_PROVIDER=legacy|keycloak|both`

--- a/docs/keycloak-migration-overview.md
+++ b/docs/keycloak-migration-overview.md
@@ -1,0 +1,467 @@
+# Keycloak AAA Migration — Overview & Design Document
+
+**Date**: 2026-02-11
+**Branch**: `auth-branch`
+**Status**: Phase 0 — Repository Understanding (NO CODE CHANGES)
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Current Authentication System Analysis](#2-current-authentication-system-analysis)
+3. [System Architecture Analysis](#3-system-architecture-analysis)
+4. [Integration Constraints](#4-integration-constraints)
+5. [Keycloak Migration Strategy](#5-keycloak-migration-strategy)
+6. [Authentication Phase — Detailed Plan](#6-authentication-phase--detailed-plan)
+7. [Risk Assessment](#7-risk-assessment)
+8. [Rollback Strategy](#8-rollback-strategy)
+
+---
+
+## 1. Executive Summary
+
+This document describes the migration from a manually implemented JWT-based authentication system to Keycloak-based AAA (Authentication, Authorization, Accounting) for the Unified Visibility Platform.
+
+**Current State**: Custom JWT auth with bcrypt password hashing, refresh token rotation, localStorage-based session management.
+
+**Target State**: Keycloak-managed authentication with OIDC/OAuth2 tokens, centralized user management, and SSO capability.
+
+**Approach**: Phased migration with parallel auth support during transition. No existing auth will be removed until replacement is fully verified.
+
+---
+
+## 2. Current Authentication System Analysis
+
+### 2.1 Login Flow
+
+```
+User (Browser)                Frontend (React)              Backend (Express)             PostgreSQL
+      |                            |                              |                          |
+      |-- Enter credentials ------>|                              |                          |
+      |                            |-- POST /api/v1/auth/signin ->|                          |
+      |                            |                              |-- SELECT user by email -->|
+      |                            |                              |<-- user row --------------|
+      |                            |                              |-- bcrypt.compare() ------>|
+      |                            |                              |-- Generate JWT pair ------>|
+      |                            |                              |-- Store refresh token ---->|
+      |                            |                              |                          |
+      |                            |<-- { accessToken,            |                          |
+      |                            |     refreshToken, user } ----|                          |
+      |                            |                              |                          |
+      |                            |-- Store in localStorage      |                          |
+      |                            |-- Redirect to / ------------>|                          |
+      |<-- Dashboard shown --------|                              |                          |
+```
+
+### 2.2 Session / Token Handling
+
+| Aspect | Implementation |
+|--------|---------------|
+| **Access Token** | JWT, signed with `JWT_SECRET` env var, 15 min expiry |
+| **Refresh Token** | JWT, signed with same `JWT_SECRET`, 7 day expiry |
+| **Token Storage (Client)** | `localStorage` under key `auth-storage` (JSON blob with user, accessToken, refreshToken, isAuthenticated) |
+| **Token Storage (Server)** | Refresh tokens stored in `refresh_tokens` table in PostgreSQL |
+| **Token Refresh** | Axios response interceptor catches 401, calls `POST /api/v1/auth/refresh`, retries original request |
+| **Token Rotation** | On signin: all old refresh tokens for user deleted, new one stored. On refresh: old token deleted, new pair issued |
+| **State Management** | Zustand store (`useAuthStore`) with `setAuth`, `logout`, `updateToken` actions |
+
+### 2.3 Password Storage
+
+- **Library**: `bcryptjs`
+- **Rounds**: 12
+- **Column**: `users.password_hash` (VARCHAR 255)
+- **Minimum Length**: 8 characters (validated via `express-validator`)
+
+### 2.4 Middleware / Guards
+
+| Middleware | File | Purpose | Used By |
+|-----------|------|---------|---------|
+| `authenticate` | `auth.middleware.js` | Validates JWT Bearer token, loads user from DB | API keys, metric configs, code generation, GET metrics |
+| `authenticateApiKey` | `auth.middleware.js` | Validates `X-API-Key` header, loads API key + user | POST /api/v1/metrics (metric ingestion) |
+| `authLimiter` | `rateLimiter.js` | 5 req/min for auth endpoints | signup, signin, password-reset |
+| `apiLimiter` | `rateLimiter.js` | 100 req/min general | API keys, metric configs, code generation |
+| `metricsLimiter` | `rateLimiter.js` | 100 req/min per API key | POST /api/v1/metrics |
+
+### 2.5 Token Usage Summary
+
+| Token Type | Format | Where Used | Validation |
+|-----------|--------|-----------|------------|
+| Access Token (JWT) | `Bearer <token>` in Authorization header | All authenticated API routes | `jwt.verify()` + DB user lookup |
+| Refresh Token (JWT) | POST body to `/api/v1/auth/refresh` | Token renewal | `jwt.verify()` + DB token lookup |
+| API Key | `X-API-Key` header or `api_key` query param | Metrics ingestion, tracker.js, metric-configs/by-api-key | DB lookup (`api_keys` table) |
+
+### 2.6 Auth Entry Points (Backend Routes)
+
+| Route | Auth Method | Purpose |
+|-------|-----------|---------|
+| `POST /api/v1/auth/signup` | None (public) | User registration |
+| `POST /api/v1/auth/signin` | None (public) | User login |
+| `POST /api/v1/auth/refresh` | Refresh token in body | Token renewal |
+| `POST /api/v1/auth/password-reset-request` | None (public) | Password reset (stub) |
+| `GET/POST/PATCH/DELETE /api/v1/api-keys/*` | JWT `authenticate` | API key management |
+| `GET/POST/PATCH/DELETE /api/v1/metric-configs/*` | JWT `authenticate` | Metric config management |
+| `GET /api/v1/metric-configs/by-api-key` | API key (no JWT) | Client library config fetch |
+| `POST /api/v1/code-generation` | JWT `authenticate` | Code snippet generation |
+| `POST /api/v1/metrics` | API key `authenticateApiKey` | Metrics ingestion from clients |
+| `GET /api/v1/metrics` | JWT `authenticate` | Metrics info page |
+| `GET /api/v1/tracker.js` | API key (query param `k`) | Dynamic JS library serving |
+| `GET /metrics` | None (public) | Prometheus scraping endpoint |
+| `GET /health` | None (public) | Health check |
+
+### 2.7 Auth Dependencies
+
+**Backend**:
+- `jsonwebtoken` ^9.0.2 — JWT sign/verify
+- `bcryptjs` ^2.4.3 — Password hashing
+- `express-validator` ^7.0.1 — Input validation
+- `express-rate-limit` ^7.1.5 — Rate limiting
+
+**Frontend**:
+- `zustand` ^4.4.7 — Auth state management
+- `axios` ^1.6.2 — HTTP client with interceptors
+- `react-router-dom` ^6.20.1 — Route protection (`PrivateRoute`)
+
+### 2.8 Database Schema (Auth-Related)
+
+```sql
+-- Users table
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  name VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Refresh tokens table
+CREATE TABLE refresh_tokens (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token VARCHAR(500) UNIQUE NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**Note**: `api_keys` and `metric_configs` tables reference `users(id)` as foreign key. This is a critical constraint — Keycloak user IDs must map to these existing relations.
+
+---
+
+## 3. System Architecture Analysis
+
+### 3.1 Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Frontend** | React 18 + Vite 5, Zustand state management, React Router 6 |
+| **Backend** | Node.js 20 + Express 5 (ESM modules) |
+| **Database** | PostgreSQL 15 (via `pg` driver) |
+| **Metrics** | Prometheus (scraping), Grafana (visualization), prom-client (registry) |
+| **Deployment** | Docker Compose (backend, prometheus, grafana; optional local postgres) |
+
+### 3.2 Auth Boundaries
+
+```
+                    ┌──────────────────────────────────────────────────┐
+                    │            PUBLIC ZONE (No Auth)                  │
+                    │                                                    │
+                    │  GET /health                                      │
+                    │  GET /metrics (Prometheus scrape)                 │
+                    │  POST /api/v1/auth/signup                        │
+                    │  POST /api/v1/auth/signin                        │
+                    │  POST /api/v1/auth/refresh                       │
+                    │  POST /api/v1/auth/password-reset-request        │
+                    └──────────────────────────────────────────────────┘
+
+                    ┌──────────────────────────────────────────────────┐
+                    │          JWT AUTH ZONE (Bearer Token)             │
+                    │                                                    │
+                    │  /api/v1/api-keys/*                               │
+                    │  /api/v1/metric-configs/* (except by-api-key)     │
+                    │  /api/v1/code-generation                          │
+                    │  GET /api/v1/metrics                              │
+                    └──────────────────────────────────────────────────┘
+
+                    ┌──────────────────────────────────────────────────┐
+                    │          API KEY AUTH ZONE (X-API-Key)            │
+                    │                                                    │
+                    │  POST /api/v1/metrics (ingestion)                │
+                    │  GET /api/v1/tracker.js?k=<key>                  │
+                    │  GET /api/v1/metric-configs/by-api-key           │
+                    └──────────────────────────────────────────────────┘
+```
+
+### 3.3 API Structure
+
+- All API routes under `/api/v1/`
+- RESTful design
+- JSON request/response
+- Centralized error handler middleware
+- CORS: strict for admin frontend, permissive for metrics/tracker endpoints
+
+### 3.4 Deployment Model
+
+- Backend runs in Docker container (port 3000)
+- Frontend runs as Vite dev server (port 5173) or static build
+- PostgreSQL can be local Docker or external (e.g., Render.com)
+- Prometheus scrapes backend `/metrics` endpoint
+- Grafana connects to Prometheus datasource
+- Docker Compose orchestrates backend + prometheus + grafana
+
+---
+
+## 4. Integration Constraints
+
+### 4.1 Where Auth is Enforced
+
+1. **Backend middleware** (`auth.middleware.js`): `authenticate` function on protected routes
+2. **Frontend route guard** (`App.jsx`): `PrivateRoute` component checks `isAuthenticated` from Zustand store
+3. **Frontend API client** (`client.js`): Axios interceptor auto-attaches Bearer token, handles 401 with refresh logic
+4. **API Key validation**: Separate middleware for client-facing endpoints
+
+### 4.2 External Clients
+
+- **Client websites** use API keys (not JWT) to send metrics. These are NOT affected by the auth migration.
+- **Prometheus** scrapes `/metrics` endpoint (no auth). NOT affected.
+- **Grafana** connects to Prometheus. NOT affected.
+
+### 4.3 Service-to-Service Auth
+
+- No service-to-service auth currently exists
+- Prometheus -> Backend `/metrics` is unauthenticated (by design)
+- All inter-service communication is within Docker network
+
+### 4.4 Monitoring Impact
+
+- The `/metrics` endpoint must remain public for Prometheus
+- Health check `/health` must remain public
+- No auth changes should affect metric collection pipeline
+- API Key-based endpoints must remain untouched during migration
+
+### 4.5 Critical Constraint: User ID Mapping
+
+The `users.id` (SERIAL/integer) is referenced as foreign key by:
+- `refresh_tokens.user_id`
+- `api_keys.user_id`
+- `metric_configs.user_id`
+
+Keycloak generates UUID-based user IDs. **We must maintain the existing integer `users.id` as the primary reference** and create a mapping column (e.g., `keycloak_id`) or use a mapping table. We CANNOT change the `users.id` type without breaking all FK relationships.
+
+---
+
+## 5. Keycloak Migration Strategy
+
+### 5.1 Phased Approach
+
+| Step | Name | Description | Status |
+|------|------|------------|--------|
+| 0 | Repository Understanding | Analyze codebase, document current auth | **DONE** |
+| 1 | Keycloak Infrastructure | Add Keycloak to Docker Compose, configure realm | **DONE** |
+| 2 | Backend Token Validation | Add Keycloak token verification alongside existing JWT | Pending |
+| 3 | Frontend OIDC Integration | Add Keycloak JS adapter, parallel auth | Pending |
+| 4 | User Migration & Mapping | Migrate existing users, establish ID mapping | Pending |
+| 5 | Cutover & Cleanup | Remove old auth code after verification | Pending (needs approval) |
+
+### 5.2 Parallel Auth Strategy
+
+During transition, the backend will support BOTH:
+1. **Existing JWT** (current `authenticate` middleware)
+2. **Keycloak OIDC tokens** (new middleware)
+
+A feature flag (`AUTH_PROVIDER=legacy|keycloak|both`) will control which auth is active.
+
+### 5.3 Architecture After Migration
+
+```
+User (Browser)         Keycloak              Frontend (React)         Backend (Express)       PostgreSQL
+     |                     |                       |                        |                      |
+     |-- Login ----------->|                       |                        |                      |
+     |<-- Keycloak form ---|                       |                        |                      |
+     |-- Credentials ----->|                       |                        |                      |
+     |<-- OIDC tokens -----|                       |                        |                      |
+     |                     |                       |                        |                      |
+     |-- Access app ------>|                       |                        |                      |
+     |                     |                       |-- API call w/ token -->|                      |
+     |                     |                       |                        |-- Verify token       |
+     |                     |                       |                        |   (Keycloak public   |
+     |                     |                       |                        |    key / JWKS)       |
+     |                     |                       |                        |-- Map KC user to     |
+     |                     |                       |                        |   local user ------->|
+     |                     |                       |<-- Response ----------|                      |
+```
+
+---
+
+## 6. Authentication Phase — Detailed Plan
+
+### Step 1: Keycloak Infrastructure Setup
+
+**What changes**:
+- Add Keycloak to `docker/docker-compose.yml` (uses cloud PostgreSQL with separate `keycloak` schema)
+- Create realm configuration (JSON export)
+- Configure OIDC client for the frontend app
+- Configure OIDC client for the backend (for token validation)
+
+**Files affected**:
+- `docker/docker-compose.yml` (add keycloak service)
+- `docker/keycloak/` (new directory for realm config)
+- `docs/keycloak-auth-step-1.md` (documentation)
+
+**No application code changes.**
+
+### Step 2: Backend — Dual Token Validation
+
+**What changes**:
+- Install `keycloak-connect` or `jwks-rsa` + `jose` for OIDC token verification
+- Create new middleware `keycloak.middleware.js`
+- Create wrapper middleware that tries Keycloak first, falls back to legacy JWT
+- Add user mapping logic (Keycloak UUID -> local user ID)
+- Add `keycloak_id` column to `users` table
+- Feature flag: `AUTH_PROVIDER` env var
+
+**Files affected**:
+- `backend/package.json` (new dependency)
+- `backend/src/middleware/keycloak.middleware.js` (new)
+- `backend/src/middleware/auth.middleware.js` (wrap with dual-auth logic)
+- `backend/src/database/connection.js` (migration for `keycloak_id` column)
+- `docs/keycloak-auth-step-2.md`
+
+**Existing auth remains fully functional.**
+
+### Step 3: Frontend — OIDC Integration
+
+**What changes**:
+- Install `keycloak-js` adapter
+- Create Keycloak initialization module
+- Update `authStore.js` to support Keycloak tokens
+- Update Login/Signup pages with Keycloak redirect option
+- Update Axios client to use Keycloak tokens when available
+- Feature flag: `VITE_AUTH_PROVIDER` env var
+
+**Files affected**:
+- `frontend/package.json` (new dependency)
+- `frontend/src/store/authStore.js` (dual auth support)
+- `frontend/src/api/client.js` (dual token attachment)
+- `frontend/src/pages/Login/index.jsx` (Keycloak login button)
+- `frontend/src/pages/Signup/index.jsx` (Keycloak signup link)
+- `frontend/src/App.jsx` (Keycloak initialization)
+- `docs/keycloak-auth-step-3.md`
+
+**Existing login form remains functional.**
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Keycloak downtime breaks auth | High | Parallel auth with fallback to legacy JWT |
+| User ID mismatch (UUID vs integer) | Critical | Mapping column `keycloak_id` on `users` table; never replace `users.id` |
+| Token format incompatibility | Medium | JWKS-based validation, not hardcoded secret |
+| Frontend redirect loop | Medium | Feature flag to disable Keycloak redirect |
+| Existing API keys break | High | API key auth is NOT changed — completely separate path |
+| Prometheus scraping breaks | High | `/metrics` endpoint remains public — not in auth scope |
+| Docker resource increase | Low | Keycloak + its DB adds ~512MB RAM; documented in requirements |
+| Existing users lose access | Critical | User migration script + parallel auth period |
+
+---
+
+## 8. Rollback Strategy
+
+At every step, rollback is possible by:
+
+1. **Step 1** (Infrastructure): Remove Keycloak containers from docker-compose. Zero code impact.
+2. **Step 2** (Backend): Set `AUTH_PROVIDER=legacy` env var. Keycloak middleware is bypassed. No code changes needed.
+3. **Step 3** (Frontend): Set `VITE_AUTH_PROVIDER=legacy` env var. Frontend uses existing login form. No code changes needed.
+
+**Emergency rollback**: Revert to the commit before migration changes. All existing auth code is preserved until explicit removal is approved.
+
+---
+
+## Appendix A: Files Inventory (Auth-Related)
+
+### Backend
+| File | Role |
+|------|------|
+| `backend/index.js` | Express app setup, route mounting, CORS config |
+| `backend/src/middleware/auth.middleware.js` | JWT `authenticate` + API key `authenticateApiKey` |
+| `backend/src/middleware/errorHandler.js` | `UnauthorizedError` class, error handler |
+| `backend/src/middleware/rateLimiter.js` | `authLimiter`, `apiLimiter`, `metricsLimiter` |
+| `backend/src/routes/auth.routes.js` | Signup, signin, refresh, password-reset routes |
+| `backend/src/routes/apikey.routes.js` | API key CRUD (uses `authenticate`) |
+| `backend/src/routes/metricconfig.routes.js` | Metric config CRUD (uses `authenticate`) |
+| `backend/src/routes/metrics.routes.js` | Metrics ingestion (uses `authenticateApiKey`) |
+| `backend/src/routes/codeGeneration.routes.js` | Code gen (uses `authenticate`) |
+| `backend/src/routes/tracker.routes.js` | Tracker.js serving (uses API key query param) |
+| `backend/src/routes/health.routes.js` | Health check (public) |
+| `backend/src/database/connection.js` | DB pool, migrations (users, refresh_tokens tables) |
+
+### Frontend
+| File | Role |
+|------|------|
+| `frontend/src/App.jsx` | `PrivateRoute` component, route definitions |
+| `frontend/src/store/authStore.js` | Zustand auth state (user, tokens, isAuthenticated) |
+| `frontend/src/api/client.js` | Axios instance with auth interceptors |
+| `frontend/src/api/auth.js` | `authAPI.signup()`, `authAPI.signin()` |
+| `frontend/src/pages/Login/index.jsx` | Login form UI |
+| `frontend/src/pages/Signup/index.jsx` | Signup form UI |
+
+### Infrastructure
+| File | Role |
+|------|------|
+| `docker/docker-compose.yml` | Service definitions (backend, prometheus, grafana) |
+| `docker/prometheus/prometheus.yml` | Prometheus scrape config |
+| `docker/.env` | Environment variables (JWT_SECRET, DB creds, etc.) |
+
+---
+
+## Appendix B: Environment Variables (Auth-Related)
+
+| Variable | Default | Used In | Purpose |
+|----------|---------|---------|---------|
+| `JWT_SECRET` | `your-secret-key-change-in-production` | auth.routes.js, auth.middleware.js | JWT signing key |
+| `JWT_ACCESS_EXPIRY` | `15m` | auth.routes.js | Access token TTL |
+| `JWT_REFRESH_EXPIRY` | `7d` | auth.routes.js | Refresh token TTL |
+| `FRONTEND_URL` | `http://localhost:5173` | index.js (CORS) | Allowed origin |
+| `VITE_API_BASE_URL` | `http://localhost:3000` | frontend client.js | Backend URL |
+
+### New Variables (To Be Added)
+| Variable | Purpose |
+|----------|---------|
+| `AUTH_PROVIDER` | `legacy` / `keycloak` / `both` — controls active auth method |
+| `KEYCLOAK_URL` | Keycloak server URL |
+| `KEYCLOAK_REALM` | Keycloak realm name |
+| `KEYCLOAK_CLIENT_ID` | Backend OIDC client ID |
+| `KEYCLOAK_CLIENT_SECRET` | Backend OIDC client secret |
+| `VITE_AUTH_PROVIDER` | Frontend auth provider flag |
+| `VITE_KEYCLOAK_URL` | Frontend Keycloak URL |
+| `VITE_KEYCLOAK_REALM` | Frontend Keycloak realm |
+| `VITE_KEYCLOAK_CLIENT_ID` | Frontend OIDC client ID |
+
+---
+
+## Appendix C: Verification Checklist (Phase 0)
+
+- [x] Current login flow documented
+- [x] Session handling documented
+- [x] Password storage mechanism documented
+- [x] All middleware/guards identified
+- [x] All token types and usage documented
+- [x] All auth entry points cataloged
+- [x] All auth dependencies listed
+- [x] Database schema (auth tables) documented
+- [x] Backend framework and structure analyzed
+- [x] Frontend framework and structure analyzed
+- [x] Auth boundaries mapped (public / JWT / API key zones)
+- [x] API structure documented
+- [x] Deployment model documented
+- [x] Auth enforcement points identified
+- [x] External client impact assessed (API keys, Prometheus — no impact)
+- [x] Service-to-service auth assessed (none exists)
+- [x] Monitoring impact assessed (no impact on /metrics)
+- [x] User ID mapping constraint identified (integer FK vs Keycloak UUID)
+- [x] Migration strategy defined (5 steps with parallel auth)
+- [x] Risk assessment completed
+- [x] Rollback strategy defined


### PR DESCRIPTION
## Summary
- Added Keycloak (v26.0) as an identity provider service in Docker Compose, configured to share the existing cloud PostgreSQL using a separate `keycloak` schema for full data isolation
- Added pre-configured realm export (`unified-visibility`) with two OIDC clients: `uv-frontend` (public, PKCE) and `uv-backend` (confidential, service account)
- Added migration overview and step-1 documentation

## Test Plan
- [ ] `docker compose up -d` succeeds — all containers running
- [ ] Keycloak admin console accessible at `http://localhost:8080` (login: `superadmin`/`admin123`)
- [ ] `unified-visibility` realm exists with `uv-frontend` and `uv-backend` clients
- [ ] OIDC discovery endpoint returns valid JSON:
      `curl http://localhost:8080/realms/unified-visibility/.well-known/openid-configuration`
- [ ] Existing backend (`/health`), frontend, Prometheus, and Grafana all still work as before
- [ ] Cloud DB shows separate `keycloak` schema; `public` schema (app tables) is untouched

## Next Step

Step 2 — Backend Dual Token Validation (install JWKS library, add Keycloak middleware, support `AUTH_PROVIDER=legacy|keycloak|both`).