### PR TITLE
Enhance: API_Key & Code_Generation Flow

### DIFF
--- a/frontend/src/api/apiKeys.js
+++ b/frontend/src/api/apiKeys.js
@@ -7,6 +7,15 @@ export const apiKeysAPI = {
     return response.data;
   },
 
+  /**
+   * Get the user's primary (user-level) API key.
+   * Returns { has_key, data } — data is null when no key exists yet.
+   */
+  getUserKey: async () => {
+    const response = await client.get('/api-keys/user-key');
+    return response.data;
+  },
+
   /** Manually create a new API key. Raw key is in the response for one-time clipboard copy. */
   create: async (keyName) => {
     const response = await client.post('/api-keys', {
@@ -16,15 +25,12 @@ export const apiKeysAPI = {
   },
 
   /**
-   * Idempotent ensure — returns the existing key (masked) or creates a new one.
+   * Idempotent ensure — returns the existing user-level key (masked) or creates one.
    * When `is_new` is true the response contains `data.api_key` for one-time copy.
-   *
-   * @param {number|null} metricConfigId - optional metric config to scope the key to
+   * One key per user — covers all current and future metric configurations.
    */
-  ensure: async (metricConfigId = null) => {
-    const response = await client.post('/api-keys/ensure', {
-      metric_config_id: metricConfigId,
-    });
+  ensure: async () => {
+    const response = await client.post('/api-keys/ensure');
     return response.data;
   },
 

--- a/frontend/src/api/codeGeneration.js
+++ b/frontend/src/api/codeGeneration.js
@@ -1,17 +1,21 @@
 import client from './client';
 
 export const codeGenerationAPI = {
-  generate: async (apiKeyId, metricConfigId, options = {}) => {
+  /**
+   * Generate the tracking code snippet.
+   *
+   * `apiKeyId` is optional — when omitted the backend auto-resolves the
+   * user's primary API key.  The generated snippet covers ALL metric
+   * configurations for the user.
+   */
+  generate: async (apiKeyId = null, options = {}) => {
     const body = {
-      api_key_id: apiKeyId,
       auto_track: options.autoTrack !== false,
       custom_events: options.customEvents !== false,
     };
 
-    // Only include metric_config_id when it is a real integer — avoids
-    // sending `null` which express-validator's optional() can reject.
-    if (metricConfigId != null) {
-      body.metric_config_id = metricConfigId;
+    if (apiKeyId != null) {
+      body.api_key_id = apiKeyId;
     }
 
     const response = await client.post('/code-generation', body);

--- a/frontend/src/api/onboarding.js
+++ b/frontend/src/api/onboarding.js
@@ -1,0 +1,27 @@
+import client from './client';
+
+export const onboardingAPI = {
+  /**
+   * Fetch the authenticated user's onboarding / setup status.
+   *
+   * Returns:
+   *   has_metric_configs  — at least one metric config exists
+   *   metric_configs_count
+   *   has_api_key         — a user-level API key exists
+   *   onboarding_completed_at — timestamp or null
+   *   is_setup_complete   — all three conditions are met
+   */
+  getStatus: async () => {
+    const response = await client.get('/auth/onboarding-status');
+    return response.data;
+  },
+
+  /**
+   * Mark the user's onboarding as complete (idempotent).
+   * Called after the Code Generation step.
+   */
+  markComplete: async () => {
+    const response = await client.post('/auth/onboarding-complete');
+    return response.data;
+  },
+};

--- a/frontend/src/pages/Dashboard/Dashboard.css
+++ b/frontend/src/pages/Dashboard/Dashboard.css
@@ -23,6 +23,98 @@
   color: var(--text-secondary);
 }
 
+/* ── Setup Complete Banner ─────────────────────────────────────── */
+.setup-complete-banner {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(16, 185, 129, 0.06) 100%);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  border-radius: 16px;
+  padding: 1.25rem 1.75rem;
+  margin-bottom: 2rem;
+}
+
+[data-theme='dark'] .setup-complete-banner {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.12) 0%, rgba(16, 185, 129, 0.08) 100%);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.setup-complete-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .setup-complete-icon {
+  color: #4ade80;
+}
+
+.setup-complete-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.setup-complete-title {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #15803d;
+  margin-bottom: 0.25rem;
+}
+
+[data-theme='dark'] .setup-complete-title {
+  color: #4ade80;
+}
+
+.setup-complete-text {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.setup-complete-link {
+  white-space: nowrap;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #16a34a;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .setup-complete-link {
+  color: #4ade80;
+}
+
+.setup-complete-link:hover {
+  text-decoration: underline;
+}
+
+/* ── Step Done Badge ──────────────────────────────────────────── */
+.step-done-badge {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #16a34a;
+  background: rgba(34, 197, 94, 0.12);
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+[data-theme='dark'] .step-done-badge {
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.18);
+}
+
 .overview-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -442,6 +534,18 @@
 @media (max-width: 900px) {
   .overview-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .setup-complete-banner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .setup-complete-link {
+    align-self: flex-end;
   }
 }
 


### PR DESCRIPTION
## Enhance: API Key & Code Generation Flow

### Summary

Refactors the API key model from a **per-metric-configuration key** to a **single user-level API key** that universally covers all current and future metric configurations. Introduces an **onboarding status tracking system** (`onboarding_completed_at`) and adds **smart navigation logic** throughout the setup flow so returning users are routed directly to the appropriate next step rather than repeating completed stages. The Dashboard now reflects real-time setup progress with visual indicators and a "Setup Complete" banner.

---

### Problem

1. **Key-per-metric friction:** Previously, a separate API key was generated (or ensured) for each `metric_config_id`. This forced users to manage multiple keys, re-generate keys when adding new metrics, and pass a `metric_config_id` into the code-generation endpoint — adding unnecessary complexity.

2. **No onboarding awareness:** The application had no concept of whether a user had completed the setup flow. Every visit to the Dashboard or metric-config form treated the user as a first-time visitor — showing the same "get started" UI even after setup was done.

3. **Rigid post-creation redirects:** After creating a new metric configuration, users were always sent to the API Keys page regardless of whether they already had a key and snippet configured, leading to redundant steps.

---

### How It Solves

#### Backend (3 files changed)

| Area | Change |
|---|---|
| **Database migration** (`connection.js`) | Adds `onboarding_completed_at TIMESTAMP` column to `users` table; retains the legacy per-metric unique index for backward compatibility. |
| **API Key routes** (`apikey.routes.js`) | New `GET /user-key` endpoint returns the user's primary key (masked). `POST /ensure` no longer accepts `metric_config_id` — it creates/returns a single user-level key (`metric_config_id IS NULL`). Race-condition handling preserved. |
| **Auth routes** (`auth.routes.js`) | Two new authenticated endpoints: `GET /onboarding-status` (returns `has_metric_configs`, `has_api_key`, `is_setup_complete` in parallel queries) and `POST /onboarding-complete` (idempotent timestamp write). |
| **Code Generation routes** (`codeGeneration.routes.js`) | `api_key_id` is now optional — backend auto-resolves the user's primary key when omitted. Always fetches ALL metric configs for the snippet. Automatically marks onboarding complete after successful generation. |

#### Frontend (6 files changed)

| Area | Change |
|---|---|
| **API layer** (`apiKeys.js`, `codeGeneration.js`, new `onboarding.js`) | `ensure()` no longer takes `metricConfigId`. `generate()` makes `apiKeyId` optional. New `onboardingAPI` module wraps status and completion endpoints. |
| **API Keys page** (`ApiKeys/index.jsx`) | Removes metric-config dependency; auto-ensures a single user-level key on mount. Updated copy: "One key for your entire account," "Universal Coverage," "Your Account Key." |
| **Code Generation page** (`CodeGeneration/index.jsx`) | Removes per-metric dropdown selector; displays "Covers all N metric configurations automatically." Calls `onboardingAPI.markComplete()` on "Complete Setup." |
| **Dashboard** (`Dashboard/index.jsx`, `Dashboard.css`) | Fetches onboarding status on mount. Quick Start timeline steps now show dynamic **Done** badges and contextual copy. "Setup Complete" banner appears when all three steps are finished. Responsive styles added for the banner. |
| **Metric Config Form** (`MetricConfigForm.jsx`) | Smart post-create redirect: if setup is already complete → Dashboard with toast; if API key exists but no snippet → Code Generation; otherwise → API Keys (default for new users). |

---

### Testing

#### Backend

- [ ] **`GET /api-keys/user-key`** — Returns `has_key: true` with masked key for users who have one; returns `has_key: false` and `data: null` for new users.
- [ ] **`POST /api-keys/ensure`** — Creates a user-level key on first call (returns `is_new: true` with raw `api_key`); returns the existing masked key on subsequent calls (`is_new: false`). Verify no `metric_config_id` is required.
- [ ] **Race condition** — Simulate concurrent `POST /ensure` calls; verify the unique constraint violation is handled gracefully (returns existing key, no 500).
- [ ] **`GET /auth/onboarding-status`** — Returns correct booleans for `has_metric_configs`, `has_api_key`, and `is_setup_complete` across fresh and returning users.
- [ ] **`POST /auth/onboarding-complete`** — Sets `onboarding_completed_at` only once (idempotent). Verify subsequent calls do not update the timestamp.
- [ ] **`POST /code-generation`** — Works without `api_key_id` (auto-resolves user's primary key). Returns snippet covering all metric configs. Marks onboarding complete as a side effect.
- [ ] **Database migration** — Verify `onboarding_completed_at` column is added to `users` table. Confirm legacy `idx_api_keys_user_metric_config` index is preserved.

#### Frontend

- [ ] **New user flow** — Register → Create Metric Config → redirected to API Keys → key auto-ensured and copied → navigate to Code Generation → snippet generated → "Complete Setup" → Dashboard shows "Setup Complete" banner.
- [ ] **Returning user (setup complete)** — Dashboard loads with green "Setup Complete" banner, all Quick Start steps show "Done" badges.
- [ ] **Returning user creates new metric** — After creating a new config, toast says "Your existing API key & snippet already cover it automatically" and redirects to Dashboard (not API Keys).
- [ ] **Returning user with key but no snippet** — After creating a metric, redirects to Code Generation page instead of API Keys.
- [ ] **API Keys page** — Only one "Account API Key" shown. Copy button works. Subtitle reads "One key for your entire account."
- [ ] **Code Generation page** — No per-metric dropdown. Badge reads "Covers all N metric configurations automatically." Framework snippets generate correctly for all tabs (JavaScript, React, Next.js, Angular).
- [ ] **Responsive** — "Setup Complete" banner stacks vertically on viewports ≤ 640px.
- [ ] **Error states** — Verify graceful degradation when onboarding status API fails (Dashboard still loads, smart redirect falls back to default).

---

### Glimpse of Enhancement
https://github.com/user-attachments/assets/2a09b14c-0c07-4c94-9319-ba6221598d55


---
closes #90 

