### PR TITLE
feat(grafana): auto-provision and set org default dashboard

### DIFF
--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -7,7 +7,14 @@ import { query } from '../database/connection.js';
 import { authenticate } from '../middleware/auth.middleware.js';
 import { authLimiter } from '../middleware/rateLimiter.js';
 import { BadRequestError, UnauthorizedError } from '../middleware/errorHandler.js';
-import { setupUserGrafanaOrg, checkOrgExists, ADMIN_AUTH, GRAFANA_URL } from '../services/grafana.service.js';
+import {
+  setupUserGrafanaOrg,
+  checkOrgExists,
+  ensureDefaultDashboardInOrg,
+  setOrgHomeDashboard,
+  ADMIN_AUTH,
+  GRAFANA_URL,
+} from '../services/grafana.service.js';
 
 const router = express.Router();
 
@@ -352,6 +359,16 @@ router.post('/grafana-session', authenticate, async (req, res) => {
       }
     } catch (err) {
       console.error('Failed to switch Grafana org:', err);
+    }
+  }
+
+  if (orgId) {
+    try {
+      const dash = await ensureDefaultDashboardInOrg(orgId);
+      await setOrgHomeDashboard(orgId, dash.uid, dash.id);
+    } catch (err) {
+      console.error('Failed to ensure default Grafana dashboard:', err);
+      // non-fatal: keep login flow working
     }
   }
 

--- a/backend/src/services/grafana.service.js
+++ b/backend/src/services/grafana.service.js
@@ -95,11 +95,169 @@ export async function createDatasourceInOrg(orgId) {
   }
 }
 
+// Build org-scoped headers once
+const orgHeaders = (orgId) => ({
+  ...headers,
+  'X-Grafana-Org-Id': String(orgId),
+});
+
+// Fixed UID for your default tenant dashboard
+const DEFAULT_DASHBOARD_UID = 'vizme-default';
+
+// Creates a starter timeseries dashboard JSON
+function buildDefaultDashboard() {
+  return {
+    uid: DEFAULT_DASHBOARD_UID,
+    title: 'Vizme - Default Metrics',
+    schemaVersion: 39,
+    version: 1,
+    timezone: 'browser',
+    refresh: '5s',
+    tags: ['vizme', 'default'],
+    editable: true,
+    time: { from: 'now-1h', to: 'now' },
+    panels: [
+      // 1) Quick KPI
+      {
+        id: 1,
+        type: 'stat',
+        title: 'Active Metric Series',
+        gridPos: { h: 6, w: 6, x: 0, y: 0 },
+        datasource: 'Prometheus',
+        targets: [
+          {
+            refId: 'A',
+            expr: 'count({__name__=~"user_metric_.*"})',
+          },
+        ],
+        options: {
+          reduceOptions: { calcs: ['lastNotNull'], values: false },
+          colorMode: 'value',
+          graphMode: 'none',
+        },
+      },
+
+      // 2) Counter traffic only (clean rate chart)
+      {
+        id: 2,
+        type: 'timeseries',
+        title: 'Request/Event Throughput (per sec)',
+        gridPos: { h: 10, w: 18, x: 6, y: 0 },
+        datasource: 'Prometheus',
+        targets: [
+          {
+            refId: 'A',
+            expr: 'sum by (__name__) (rate({__name__=~"user_metric_.*_total"}[1m]))',
+            legendFormat: '{{__name__}}',
+          },
+        ],
+        fieldConfig: {
+          defaults: { unit: 'ops' },
+          overrides: [],
+        },
+        options: {
+          legend: { displayMode: 'table', placement: 'bottom' },
+          tooltip: { mode: 'multi' },
+        },
+      },
+
+      // 3) Gauge/current values panel (no rate)
+      {
+        id: 3,
+        type: 'timeseries',
+        title: 'Current Values (Gauges/Instant Metrics)',
+        gridPos: { h: 10, w: 24, x: 0, y: 6 },
+        datasource: 'Prometheus',
+        targets: [
+          {
+            refId: 'A',
+            expr: '{__name__=~"user_metric_.*",__name__!~".*(_total|_count|_sum|_bucket|_created)$"}',
+            legendFormat: '{{__name__}}',
+          },
+        ],
+        options: {
+          legend: { displayMode: 'table', placement: 'bottom' },
+          tooltip: { mode: 'multi' },
+        },
+      },
+    ],
+  };
+}
+
+// Ensure dashboard exists in org (idempotent)
+export async function ensureDefaultDashboardInOrg(orgId) {
+  // 1) Check if dashboard already exists
+  const getRes = await fetch(`${GRAFANA_URL}/api/dashboards/uid/${DEFAULT_DASHBOARD_UID}`, {
+    method: 'GET',
+    headers: orgHeaders(orgId),
+  });
+
+  if (getRes.ok) {
+    const data = await getRes.json();
+    return { id: data.dashboard.id, uid: data.dashboard.uid, created: false };
+  }
+
+  if (getRes.status !== 404) {
+    const body = await getRes.text();
+    throw new Error(`Failed checking default dashboard in org ${orgId}: ${getRes.status} ${body}`);
+  }
+
+  // 2) Create dashboard when missing
+  const createPayload = {
+    dashboard: buildDefaultDashboard(),
+    folderId: 0,
+    overwrite: false,
+    message: 'Create Vizme default dashboard',
+  };
+
+  const createRes = await fetchWithRetry(`${GRAFANA_URL}/api/dashboards/db`, {
+    method: 'POST',
+    headers: orgHeaders(orgId),
+    body: JSON.stringify(createPayload),
+  });
+
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(
+      `Failed creating default dashboard in org ${orgId}: ${createRes.status} ${body}`
+    );
+  }
+
+  const created = await createRes.json();
+  return { id: created.id, uid: created.uid, created: true };
+}
+
+// Set org home dashboard so opening Grafana lands here
+export async function setOrgHomeDashboard(orgId, dashboardUid, dashboardId) {
+  const payload = {
+    theme: '',
+    timezone: '',
+    homeDashboardUID: dashboardUid,
+    homeDashboardId: dashboardId, // optional but useful for compatibility
+  };
+
+  const res = await fetchWithRetry(`${GRAFANA_URL}/api/org/preferences`, {
+    method: 'PUT',
+    headers: orgHeaders(orgId),
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed setting home dashboard for org ${orgId}: ${res.status} ${body}`);
+  }
+}
+
 // 6. Full setup: called once during signup
 export async function setupUserGrafanaOrg(userId, email, name) {
   const org = await createOrg(`vizme-user-${userId}`);
   const user = await createGrafanaUser(email, name, org.orgId);
+
   await setUserOrgRole(org.orgId, user.id, 'Editor');
   await createDatasourceInOrg(org.orgId);
+
+  const dash = await ensureDefaultDashboardInOrg(org.orgId);
+  await setOrgHomeDashboard(org.orgId, dash.uid, dash.id);
+
   return org.orgId;
 }


### PR DESCRIPTION
## Summary
- Added org-scoped dashboard provisioning utilities in `backend/src/services/grafana.service.js`.
- Ensured each user org has a default Grafana dashboard and configured it as the org home dashboard.
- Updated auth flow in `backend/src/routes/auth.routes.js` to run dashboard setup after org creation/lazy initialization, with non-fatal error handling to avoid blocking login.

## Why
- Improves first-time Grafana experience by landing users on a ready-to-use dashboard.
- Keeps tenant behavior isolated by creating/configuring dashboards per org.
- Reduces manual setup steps for newly provisioned users.

## What changed
- Introduced a fixed default dashboard UID (`vizme-default`) and default dashboard JSON builder.
- Added idempotent `ensureDefaultDashboardInOrg(orgId)`:
  - checks for dashboard by UID in the org
  - creates it only when missing
- Added `setOrgHomeDashboard(orgId, dashboardUid, dashboardId)` to set org preferences.
- Updated `setupUserGrafanaOrg(...)` to provision datasource + default dashboard + home dashboard.
- In auth login/lazy-org path, invoked default dashboard setup and kept failures non-blocking (logged only).

## Impact
- New users (and users with lazily created orgs) now get a consistent default landing dashboard.
- Existing login flow remains resilient if Grafana dashboard API calls fail.

## Test plan
- [ ] Create a new user and verify a Grafana org is provisioned.
- [ ] Log in and confirm default dashboard (`vizme-default`) is present in that org.
- [ ] Verify Grafana opens to the configured home dashboard.
- [ ] Log in again and confirm idempotency (no duplicate dashboard creation).
- [ ] Simulate Grafana API failure and verify login still succeeds while errors are logged.

closes #103 