### PR TITLE
feat: Added ForbiddenError and 403 handling

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -19,6 +19,15 @@ export const errorHandler = (err, req, res, next) => {
     });
   }
 
+  // Authorization errors (authenticated but insufficient permissions)
+  if (err.name === 'ForbiddenError') {
+    return res.status(403).json({
+      success: false,
+      error: 'Forbidden',
+      message: err.message || 'Insufficient permissions'
+    });
+  }
+
   // Database errors
   if (err.code === '23505') { // Unique violation
     return res.status(409).json({
@@ -65,6 +74,13 @@ export class UnauthorizedError extends AppError {
   constructor(message = 'Unauthorized') {
     super(message, 401);
     this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Insufficient permissions') {
+    super(message, 403);
+    this.name = 'ForbiddenError';
   }
 }
 


### PR DESCRIPTION
## Summary
This change introduces handling for `ForbiddenError` so that requests without sufficient permissions return a **403 Forbidden** response with the standardized JSON error structure.

## Testing
- **Manual verification:** Throw a `ForbiddenError` from any route (or use a test route) and it confirms that the API returns **HTTP 403** along with the expected JSON response structure.
- **Unauthenticated requests:** The current behavior is preserved—requests without authentication still return HTTP 401 as before.
---
**401 Unauthorized**: No token, invalid token, or expired token. Use existing `UnauthorizedError`.
**403 Forbidden**: Valid token but insufficient permissions. Use new `ForbiddenError` and ensure error handler returns 403.
