### PR TITLE
auth step3 implemented

### DIFF
--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -15,6 +15,18 @@ import { authenticateKeycloak } from './keycloak.middleware.js';
 // Re-export Keycloak middleware as the single authenticate middleware
 export const authenticate = authenticateKeycloak;
 
+// Authorization helpers (use after `authenticate` on routes)
+export {
+  requireRole,
+  requireClientRole,
+  requireBackendClientRole,
+  getKeycloakRoles,
+  getKeycloakClientRoles,
+  hasRealmRole,
+  hasClientRole,
+  isPlatformAdmin,
+} from './keycloak.middleware.js';
+
 // ─── API Key Authentication (unchanged) ─────────────────────────────────
 
 /**

--- a/backend/src/middleware/keycloak.middleware.js
+++ b/backend/src/middleware/keycloak.middleware.js
@@ -19,7 +19,7 @@
 
 import * as jose from 'jose';
 import { query } from '../database/connection.js';
-import { UnauthorizedError } from './errorHandler.js';
+import { ForbiddenError, UnauthorizedError } from './errorHandler.js';
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 
@@ -217,19 +217,79 @@ export const getKeycloakRoles = (payload) => {
 };
 
 /**
+ * Extract client roles for a given Keycloak client id from the token payload.
+ * @param {object} payload  Verified JWT payload
+ * @param {string} clientId  e.g. uv-backend (same as KEYCLOAK_CLIENT_ID)
+ * @returns {string[]}
+ */
+export const getKeycloakClientRoles = (payload, clientId) => {
+  if (!clientId || !payload?.resource_access) return [];
+  const entry = payload.resource_access[clientId];
+  return entry?.roles || [];
+};
+
+export const hasRealmRole = (payload, role) => {
+  return getKeycloakRoles(payload).includes(role);
+};
+
+export const hasClientRole = (payload, clientId, role) => {
+  return getKeycloakClientRoles(payload, clientId).includes(role);
+};
+
+/** True if realm PLATFORM_ADMIN or client API_ADMIN on the configured backend client. */
+export const isPlatformAdmin = (payload) => {
+  return hasRealmRole(payload, 'PLATFORM_ADMIN')
+    || hasClientRole(payload, KEYCLOAK_CLIENT_ID, 'API_ADMIN');
+};
+
+/**
  * Middleware factory: require one or more Keycloak realm roles.
  * Must be used AFTER `authenticateKeycloak` (needs `req.keycloakPayload`).
+ * Missing roles → 403 Forbidden (authenticated but not allowed).
  *
  * Usage:
- *   router.get('/admin', authenticateKeycloak, requireRole('admin'), handler);
+ *   router.get('/admin', authenticateKeycloak, requireRole('PLATFORM_ADMIN'), handler);
  */
 export const requireRole = (...roles) => {
   return (req, res, next) => {
+    if (!req.keycloakPayload) {
+      return next(new UnauthorizedError('Authentication required'));
+    }
     const userRoles = getKeycloakRoles(req.keycloakPayload);
     const hasRole = roles.some((r) => userRoles.includes(r));
     if (!hasRole) {
-      return next(new UnauthorizedError(`Required role(s): ${roles.join(', ')}`));
+      return next(new ForbiddenError(`Required realm role(s): ${roles.join(', ')}`));
     }
     next();
   };
 };
+
+/**
+ * Middleware factory: require at least one of the given client roles for `clientId`.
+ * Must be used AFTER `authenticateKeycloak`.
+ *
+ * Usage:
+ *   router.get('/x', authenticateKeycloak, requireClientRole(KEYCLOAK_CLIENT_ID, 'API_USER'), handler);
+ */
+export const requireClientRole = (clientId, ...clientRoles) => {
+  return (req, res, next) => {
+    if (!req.keycloakPayload) {
+      return next(new UnauthorizedError('Authentication required'));
+    }
+    const userRoles = getKeycloakClientRoles(req.keycloakPayload, clientId);
+    const hasRole = clientRoles.some((r) => userRoles.includes(r));
+    if (!hasRole) {
+      return next(
+        new ForbiddenError(`Required client role(s) on ${clientId}: ${clientRoles.join(', ')}`)
+      );
+    }
+    next();
+  };
+};
+
+/**
+ * Shorthand for client roles on the backend Keycloak client (KEYCLOAK_CLIENT_ID).
+ * Prefer this on routes so callers do not repeat the client id.
+ */
+export const requireBackendClientRole = (...clientRoles) =>
+  requireClientRole(KEYCLOAK_CLIENT_ID, ...clientRoles);

--- a/docs/authorization-implementation-plan.md
+++ b/docs/authorization-implementation-plan.md
@@ -333,7 +333,7 @@ Execute in this order, pausing after each step for approval before the next.
 |------|-------------|----------------|-----|
 | **1** | Keycloak: Create realm roles and client roles; assign to test users; verify token contents | Yes | [Step 1 — Keycloak config](authorization-step1-keycloak-config.md) ✓ |
 | **2** | Backend: Add `ForbiddenError` and 403 handling in errorHandler | Yes |
-| **3** | Backend: Add `getKeycloakClientRoles`, `requireClientRole`, use ForbiddenError in `requireRole`; optional helpers | Yes |
+| **3** | Backend: Add `getKeycloakClientRoles`, `requireClientRole`, use ForbiddenError in `requireRole`; optional helpers | Yes | [Step 3 — Backend helpers](authorization-step3-backend-authorization-helpers.md) ✓ |
 | **4** | Backend: Apply optional `requireClientRole('API_USER')` to chosen routes (or skip until Keycloak roles are assigned) | Yes |
 | **5** | (Future) Add admin routes and protect with `requireRole('PLATFORM_ADMIN')` or `requireClientRole('API_ADMIN')` | When admin features exist |
 | **6** | Testing: Run through 8.1–8.4 and document results | Yes |


### PR DESCRIPTION
## Summary
Implements Step 3 of the backend authorization plan (`docs/authorization-implementation-plan.md)` by adding reusable authorization helpers and enforcing proper HTTP response semantics.

## Testings
- Unit tests: `node test-auth.mjs` validates helper behavior on mock JWT payloads → outputs `all assertions passed`
- Exports check: `node -e "import('./backend/src/middleware/auth.middleware.js').then(m => console.log(Object.keys(m)))"` confirms correct exports
