### PR TITLE
Added API_USER route guards for metric APIs; update auth/testing docs

### DIFF
--- a/backend/src/routes/apikey.routes.js
+++ b/backend/src/routes/apikey.routes.js
@@ -2,14 +2,15 @@ import express from 'express';
 import crypto from 'crypto';
 import { body, validationResult } from 'express-validator';
 import { query } from '../database/connection.js';
-import { authenticate } from '../middleware/auth.middleware.js';
+import { authenticate, requireBackendClientRole } from '../middleware/auth.middleware.js';
 import { apiLimiter } from '../middleware/rateLimiter.js';
 import { BadRequestError, NotFoundError } from '../middleware/errorHandler.js';
 
 const router = express.Router();
 
-// All routes require authentication
+// All routes require authentication and uv-backend client role API_USER
 router.use(authenticate);
+router.use(requireBackendClientRole('API_USER'));
 router.use(apiLimiter);
 
 // ---------------------------------------------------------------------------

--- a/backend/src/routes/codeGeneration.routes.js
+++ b/backend/src/routes/codeGeneration.routes.js
@@ -1,15 +1,16 @@
 import express from 'express';
 import { body, validationResult } from 'express-validator';
 import { query } from '../database/connection.js';
-import { authenticate } from '../middleware/auth.middleware.js';
+import { authenticate, requireBackendClientRole } from '../middleware/auth.middleware.js';
 import { apiLimiter } from '../middleware/rateLimiter.js';
 import { BadRequestError, NotFoundError } from '../middleware/errorHandler.js';
 import { generateMinimalSnippet } from '../services/codeGenerator.service.js';
 
 const router = express.Router();
 
-// All routes require authentication
+// All routes require authentication and uv-backend client role API_USER
 router.use(authenticate);
+router.use(requireBackendClientRole('API_USER'));
 router.use(apiLimiter);
 
 /**

--- a/backend/src/routes/metricconfig.routes.js
+++ b/backend/src/routes/metricconfig.routes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { body, validationResult } from 'express-validator';
 import { query } from '../database/connection.js';
-import { authenticate } from '../middleware/auth.middleware.js';
+import { authenticate, requireBackendClientRole } from '../middleware/auth.middleware.js';
 import { apiLimiter } from '../middleware/rateLimiter.js';
 import { BadRequestError, NotFoundError } from '../middleware/errorHandler.js';
 
@@ -75,8 +75,9 @@ router.get('/by-api-key',
   }
 );
 
-// All routes require authentication
+// JWT routes: authentication + uv-backend client role API_USER (/by-api-key above is unchanged)
 router.use(authenticate);
+router.use(requireBackendClientRole('API_USER'));
 router.use(apiLimiter);
 
 const METRIC_TYPES = ['counter', 'gauge', 'histogram', 'summary'];

--- a/backend/src/routes/metrics.routes.js
+++ b/backend/src/routes/metrics.routes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { body, validationResult } from 'express-validator';
-import { authenticateApiKey, authenticate } from '../middleware/auth.middleware.js';
+import { authenticateApiKey, authenticate, requireBackendClientRole } from '../middleware/auth.middleware.js';
 import { metricsLimiter } from '../middleware/rateLimiter.js';
 import { BadRequestError } from '../middleware/errorHandler.js';
 import { recordMetric, getMetrics } from '../services/metrics.service.js';
@@ -145,6 +145,7 @@ router.post('/',
  */
 router.get('/',
   authenticate,
+  requireBackendClientRole('API_USER'),
   async (req, res, next) => {
     try {
       res.json({

--- a/docs/authorization-implementation-plan.md
+++ b/docs/authorization-implementation-plan.md
@@ -334,7 +334,7 @@ Execute in this order, pausing after each step for approval before the next.
 | **1** | Keycloak: Create realm roles and client roles; assign to test users; verify token contents | Yes | [Step 1 — Keycloak config](authorization-step1-keycloak-config.md) ✓ |
 | **2** | Backend: Add `ForbiddenError` and 403 handling in errorHandler | Yes |
 | **3** | Backend: Add `getKeycloakClientRoles`, `requireClientRole`, use ForbiddenError in `requireRole`; optional helpers | Yes | [Step 3 — Backend helpers](authorization-step3-backend-authorization-helpers.md) ✓ |
-| **4** | Backend: Apply optional `requireClientRole('API_USER')` to chosen routes (or skip until Keycloak roles are assigned) | Yes |
+| **4** | Backend: Apply optional `requireClientRole('API_USER')` to chosen routes (or skip until Keycloak roles are assigned) | Yes | [Step 4 — Route guards (API_USER)](authorization-step4-route-guards-api-user.md) ✓ |
 | **5** | (Future) Add admin routes and protect with `requireRole('PLATFORM_ADMIN')` or `requireClientRole('API_ADMIN')` | When admin features exist |
 | **6** | Testing: Run through 8.1–8.4 and document results | Yes |
 


### PR DESCRIPTION
## Summary
- Enforced Keycloak client role `API_USER` on user-facing metric configuration and metric viewing endpoints.
- Updated Step 4 API_USER manual test script.
- Improved route-guard and authentication documentation.

## Why 
Authentication verifies user identity, but does not enforce permissions.
These changes ensure that only users with the appropriate API_USER role can create and view metrics, improving access control and overall security.

## Testing
- [ ] Verified by logging in as an `API_USER` via browser and successfully creating a metric configuration.
- [ ] Verified via direct API calls that `API_USER` can access protected endpoints.
- [ ] Confirmed unauthorized users are blocked from accessing these endpoints.
