### PR TITLE
feat(authz): added Keycloak-protected admin routes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,7 @@ import { codeGenerationRoutes } from "./src/routes/codeGeneration.routes.js";
 import { metricsRoutes } from "./src/routes/metrics.routes.js";
 import { healthRoutes } from "./src/routes/health.routes.js";
 import { trackerRoutes } from "./src/routes/tracker.routes.js";
+import { adminRoutes } from "./src/routes/admin.routes.js";
 import { initDatabase } from "./src/database/connection.js";
 import { getMetrics } from "./src/services/metrics.service.js";
 
@@ -136,6 +137,7 @@ app.use("/api/v1/api-keys", apiKeyRoutes);
 app.use("/api/v1/metric-configs", metricConfigRoutes);
 app.use("/api/v1/code-generation", codeGenerationRoutes);
 app.use("/api/v1/metrics", metricsRoutes);
+app.use("/api/v1/admin", adminRoutes);
 app.use("/api/v1", trackerRoutes);
 
 // Error handling

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import { authenticate, isPlatformAdmin } from '../middleware/auth.middleware.js';
+import { ForbiddenError } from '../middleware/errorHandler.js';
+
+const router = express.Router();
+
+// All /api/v1/admin routes require an authenticated admin.
+router.use(authenticate);
+router.use((req, res, next) => {
+  // `req.keycloakPayload` is attached by `authenticate` (keycloak.middleware.js).
+  if (!req.keycloakPayload || !isPlatformAdmin(req.keycloakPayload)) {
+    return next(new ForbiddenError('Admin access required'));
+  }
+  next();
+});
+
+// Minimal admin endpoint to validate role protection (PLATFORM_ADMIN or API_ADMIN).
+router.get('/ping', async (req, res) => {
+  res.json({
+    success: true,
+    data: {
+      message: 'admin ok',
+      user: req.user,
+      timestamp: new Date().toISOString(),
+    },
+  });
+});
+
+export { router as adminRoutes };
+

--- a/docs/authorization-implementation-plan.md
+++ b/docs/authorization-implementation-plan.md
@@ -335,7 +335,7 @@ Execute in this order, pausing after each step for approval before the next.
 | **2** | Backend: Add `ForbiddenError` and 403 handling in errorHandler | Yes |
 | **3** | Backend: Add `getKeycloakClientRoles`, `requireClientRole`, use ForbiddenError in `requireRole`; optional helpers | Yes | [Step 3 — Backend helpers](authorization-step3-backend-authorization-helpers.md) ✓ |
 | **4** | Backend: Apply optional `requireClientRole('API_USER')` to chosen routes (or skip until Keycloak roles are assigned) | Yes | [Step 4 — Route guards (API_USER)](authorization-step4-route-guards-api-user.md) ✓ |
-| **5** | (Future) Add admin routes and protect with `requireRole('PLATFORM_ADMIN')` or `requireClientRole('API_ADMIN')` | When admin features exist |
+| **5** | Add admin routes and protect with `PLATFORM_ADMIN` (realm) or `API_ADMIN` (client) | Yes | [Step 5 — Admin route guards](authorization-step5-admin-routes.md) ✓ |
 | **6** | Testing: Run through 8.1–8.4 and document results | Yes |
 
 ---


### PR DESCRIPTION
## Summary
Implemented Step 5 of the authorization plan by adding a protected admin endpoint, updating the related documentation, and including test assets for easier manual verification.

## Why was it necessary
This established a clear and reusable pattern for future admin-only endpoints under `/api/v1/admin/*` and ensured proper separation between authentication and authorization errors.

## Expected behavior
- **No token** → 401 Unauthorized
- **Non-admin token** → 403 Forbidden
- **Admin token** → 200 OK

## Manual testing
Tested using Keycloak access tokens with:
- `adminuser@example.com`
- `testuser@example.com`

- [X] Admin user received 200 OK
- [X] Non-admin user received 403 Forbidden
- [X] Missing token returned 401 Unauthorized