### PR TITLE
[UPLOAD] Library to NPM Package

### DIFF
--- a/library/LICENSE
+++ b/library/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vizme contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/library/README.md
+++ b/library/README.md
@@ -5,15 +5,24 @@ A lightweight JavaScript library for tracking metrics to your unified visibility
 ## Installation
 
 ```bash
-npm install vizme
+npm install @ganesh/vizme
 ```
+
+The package is published under the **`@ganesh`** scope on npm (public). Use this scoped name; the unscoped name `vizme` is blocked by npm (similarity with other packages).
+
+## Package entry points
+
+| Use case | Import / path |
+|----------|----------------|
+| Bundlers (Vite, Webpack, etc.) | `import Vizme from '@ganesh/vizme'` (ESM) or `const { Vizme } = require('@ganesh/vizme')` / `require('@ganesh/vizme').default` (CJS) |
+| Script tag (no bundler) | Copy or serve `node_modules/@ganesh/vizme/dist/vizme.js`; exposes `window.Vizme` |
 
 ## Quick Start
 
-### Browser
+### Browser (bundler)
 
 ```javascript
-import Vizme from 'vizme';
+import Vizme from '@ganesh/vizme';
 
 // Initialize
 const tracker = new Vizme({
@@ -31,6 +40,23 @@ window.vizme.increment('add_to_cart', 1, {
   product_name: 'Product Name'
 });
 ```
+
+### Browser (script tag, no bundler)
+
+Serve or copy `node_modules/@ganesh/vizme/dist/vizme.js` and include:
+
+```html
+<script src="/path/to/vizme.js"></script>
+<script>
+  window.vizme = new Vizme({
+    apiKey: 'mk_your_api_key_here',
+    endpoint: 'https://api.example.com/api/v1/metrics',
+    autoTrack: true
+  });
+</script>
+```
+
+`Vizme` is available as `window.Vizme` after the script loads.
 
 ### HTML Attributes (Zero Code)
 
@@ -72,6 +98,12 @@ When `autoTrack: true`, the library automatically tracks:
 - Web Vitals (FCP, LCP, FID, CLS)
 - Scroll depth
 - Time on page
+
+## Publishing (maintainers)
+
+1. **Scope**: The package name is `@ganesh/vizme`. Your npm user must match the scope (`ganesh`) or you must be a member of the `@ganesh` org with publish access.
+2. **Rename**: To publish under a different user/org, change `"name"` in `package.json` to `@your-npm-username/vizme`, then run `npm publish` from `library/` (`publishConfig.access` is already `public`).
+3. **Login**: `npm login` and `npm whoami` before publishing.
 
 ## License
 

--- a/library/build.js
+++ b/library/build.js
@@ -1,42 +1,48 @@
-import fs from 'fs';
-import path from 'path';
+/**
+ * Production build: ESM + CJS for npm consumers, IIFE for script-tag / CDN usage.
+ * No changes to src/index.js behavior — only bundling.
+ */
+import * as esbuild from 'esbuild';
 import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Read source
-let source = fs.readFileSync(
-  path.join(__dirname, 'src/index.js'),
-  'utf8'
-);
-
-// Remove ES6 export statements (they cause errors in browser script tags)
-source = source.replace(/export\s+default\s+Vizme;?\s*/g, '');
-source = source.replace(/export\s*{\s*Vizme\s*};?\s*/g, '');
-
-// Wrap in IIFE for browser compatibility
-const wrappedSource = `(function() {
-${source}
-// Expose to global scope
-if (typeof window !== 'undefined') {
-  window.Vizme = Vizme;
-}
-})();`;
-
-// Create dist directory if it doesn't exist
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const entry = path.join(__dirname, 'src/index.js');
 const distDir = path.join(__dirname, 'dist');
+
 if (!fs.existsSync(distDir)) {
   fs.mkdirSync(distDir, { recursive: true });
 }
 
-// Write to dist
-fs.writeFileSync(
-  path.join(distDir, 'vizme.js'),
-  wrappedSource,
-  'utf8'
-);
+const common = {
+  entryPoints: [entry],
+  bundle: true,
+  platform: 'browser',
+  target: ['es2018'],
+  logLevel: 'info',
+};
 
-const fileSize = fs.statSync(path.join(distDir, 'vizme.js')).size;
-console.log('✅ Built vizme.js (browser-compatible)');
-console.log(`📦 Size: ${(fileSize / 1024).toFixed(2)} KB`);
+await esbuild.build({
+  ...common,
+  format: 'esm',
+  outfile: path.join(distDir, 'vizme.esm.js'),
+});
+
+await esbuild.build({
+  ...common,
+  format: 'cjs',
+  // Must use .cjs extension: package has "type":"module", so .js is treated as ESM.
+  outfile: path.join(distDir, 'vizme.cjs'),
+});
+
+await esbuild.build({
+  ...common,
+  format: 'iife',
+  globalName: 'Vizme',
+  outfile: path.join(distDir, 'vizme.js'),
+});
+
+const iifeSize = fs.statSync(path.join(distDir, 'vizme.js')).size;
+console.log('✅ Built dist/vizme.esm.js (ESM), dist/vizme.cjs (CJS), dist/vizme.js (IIFE)');
+console.log(`📦 IIFE size: ${(iifeSize / 1024).toFixed(2)} KB`);

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,0 +1,500 @@
+{
+  "name": "@ganesh/vizme",
+  "version": "1.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ganesh/vizme",
+      "version": "1.0.2",
+      "license": "MIT",
+      "devDependencies": {
+        "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/library/package.json
+++ b/library/package.json
@@ -1,19 +1,50 @@
 {
-    "name": "vizme",
-    "version": "1.0.0",
-    "description": "Unified visibility platform - automatic metrics tracking library",
-    "type": "module",
-    "main": "dist/vizme.js",
-    "scripts": {
-      "build": "node build.js"
-    },
-    "keywords": [
-      "metrics",
-      "analytics",
-      "tracking",
-      "monitoring",
-      "prometheus"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@ganesh-40/vizme",
+  "version": "1.0.2",
+  "description": "Unified visibility platform - automatic metrics tracking library",
+  "type": "module",
+  "main": "./dist/vizme.cjs",
+  "module": "./dist/vizme.esm.js",
+  "types": "./vizme.d.ts",
+  "exports": {
+    ".": {
+      "types": "./vizme.d.ts",
+      "import": "./dist/vizme.esm.js",
+      "require": "./dist/vizme.cjs",
+      "default": "./dist/vizme.esm.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "vizme.d.ts"
+  ],
+  "scripts": {
+    "build": "node build.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "metrics",
+    "analytics",
+    "tracking",
+    "monitoring",
+    "prometheus",
+    "vizme"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Vizme/Vizme.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Vizme/Vizme/issues"
+  },
+  "homepage": "https://github.com/Vizme/Vizme#readme",
+  "devDependencies": {
+    "esbuild": "^0.25.0"
   }
+}

--- a/library/vizme.d.ts
+++ b/library/vizme.d.ts
@@ -1,0 +1,52 @@
+/**
+ * Type declarations for the Vizme browser metrics library.
+ */
+
+export interface VizmeConstructorOptions {
+  /** Required API key from the Vizme dashboard */
+  apiKey: string;
+  /** Metrics ingestion URL (default: http://localhost:3000/api/v1/metrics) */
+  endpoint?: string;
+  /** Enable automatic tracking (default: true) */
+  autoTrack?: boolean;
+  /** Fetch metric configs from the server (default: true) */
+  autofetchConfigs?: boolean;
+  batchSize?: number;
+  flushInterval?: number;
+  metricConfigs?: Record<string, { type?: string; labels?: Record<string, string> }>;
+  sampleRate?: number;
+  maxRetries?: number;
+  retryBaseMs?: number;
+  autoInteractions?: boolean;
+  [key: string]: unknown;
+}
+
+export default class Vizme {
+  constructor(options: VizmeConstructorOptions);
+
+  fetchMetricConfigs(): Promise<Record<string, { type?: string }>>;
+
+  track(name: string, value?: number, labels?: Record<string, unknown>): this;
+
+  increment(
+    name: string,
+    value?: number,
+    labels?: Record<string, unknown>
+  ): Promise<this>;
+
+  decrement(
+    name: string,
+    value?: number,
+    labels?: Record<string, unknown>
+  ): Promise<this>;
+
+  set(name: string, value: number, labels?: Record<string, unknown>): Promise<this>;
+
+  flush(): Promise<void>;
+
+  getStatus(): Record<string, unknown>;
+
+  destroy(): void;
+}
+
+export { Vizme };


### PR DESCRIPTION
# Vizme client library — npm release (`@ganesh-40/vizme`)

## Overview

The `library/` package is published to the public npm registry as **`@ganesh-40/vizme`**. Install with:

```bash
npm i @ganesh-40/vizme
```

> **Note:** The unscoped name `vizme` is not used: npm blocks it as too similar to existing packages. The scoped name satisfies registry policy.

---

## Team quick start

**Install**
```bash
npm i @ganesh-40/vizme
```

**Minimal browser usage (bundler)**
```javascript
import Vizme from '@ganesh-40/vizme';

const vizme = new Vizme({
  apiKey: import.meta.env.VITE_VIZME_API_KEY,
  endpoint: '[https://api.example.com/api/v1/metrics](https://api.example.com/api/v1/metrics)',
  autoTrack: true,
});
```

**Script tag (no bundler)** Serve `node_modules/@ganesh-40/vizme/dist/vizme.js` and use `window.Vizme` after load.

**Prerequisites**
- API key from the Vizme dashboard  
- Backend `ALLOWED_METRICS_ORIGINS` includes your site origin  

---

## Related documentation

- `docs/usingLibrary.md` — NPM workflow and backend interaction  
- `docs/PRODUCTION.md` — API URLs, CORS, production checklist  
- `library/README.md` — package-specific README on npm