### PR TITLE
Refactor: Update codegen and docs for data-vizme-* tracking attributes

### DIFF
--- a/backend/src/routes/grafana.routes.js
+++ b/backend/src/routes/grafana.routes.js
@@ -175,9 +175,7 @@ router.get('/embed-url', grafanaEmbedLimiter, authenticate, async (req, res, nex
     });
 
     const path =
-      dashboard === 'metrics'
-        ? `d/${dashboard}/${METRICS_DASHBOARD_SLUG}`
-        : `d/${dashboard}`;
+      dashboard === 'metrics' ? `d/${dashboard}/${METRICS_DASHBOARD_SLUG}` : `d/${dashboard}`;
     const url = `${baseUrl}/grafana/${path}?${params.toString()}`;
 
     if (wantsBrowserRedirect(req)) {
@@ -251,6 +249,23 @@ function buildGrafanaProxyTargetUrl(path, queryStr, upstreamOrigin) {
   const prefix = useSubpath ? '/grafana' : '';
   const qs = queryStr ? `?${queryStr}` : '';
   return `${upstreamOrigin}${prefix}${path}${qs}`;
+}
+
+function isGrafanaStaticAssetPath(path = '') {
+  return /^\/public\/build\//.test(path) || /^\/public\/plugins\//.test(path);
+}
+
+function isGrafanaOptionalFeaturePath(path = '') {
+  return (
+    path.includes('/apis/features.grafana.app/') ||
+    path.includes('/ofrep/v1/evaluate/flags')
+  );
+}
+
+function shouldClearEmbedCookieOnUpstreamAuthFailure(path = '', status) {
+  if (status !== 401 && status !== 403) return false;
+  if (isGrafanaStaticAssetPath(path) || isGrafanaOptionalFeaturePath(path)) return false;
+  return true;
 }
 
 /**
@@ -380,11 +395,7 @@ export async function grafanaProxyMiddleware(req, res, next) {
 
     let response = await fetch(targetUrl, fetchOpts);
 
-    if (
-      response.status === 404 &&
-      req.method === 'GET' &&
-      /^\/d\//.test(path)
-    ) {
+    if (response.status === 404 && req.method === 'GET' && /^\/d\//.test(path)) {
       logger.warn(
         {
           path,
@@ -402,7 +413,10 @@ export async function grafanaProxyMiddleware(req, res, next) {
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearGrafanaEmbedCookie(res);
+      const shouldClear = shouldClearEmbedCookieOnUpstreamAuthFailure(path, response.status);
+      if (shouldClear) {
+        clearGrafanaEmbedCookie(res);
+      }
       logger.warn(
         {
           status: response.status,
@@ -410,14 +424,22 @@ export async function grafanaProxyMiddleware(req, res, next) {
           method: req.method,
           userId: String(userId),
           orgId: String(orgId),
+          clearedEmbedCookie: shouldClear,
         },
-        'Grafana auth rejection; cleared embed cookie for automatic recovery'
+        shouldClear
+          ? 'Grafana auth rejection on critical path; cleared embed cookie for recovery'
+          : 'Grafana auth rejection on non-critical path; preserved embed cookie'
       );
     }
 
     if (response.status >= 400) {
       logger.warn(
-        { status: response.status, path, targetUrl: targetUrl.replace(/:[^:@]+@/, ':***@'), method: req.method },
+        {
+          status: response.status,
+          path,
+          targetUrl: targetUrl.replace(/:[^:@]+@/, ':***@'),
+          method: req.method,
+        },
         'Grafana proxy non-2xx response'
       );
     }
@@ -429,9 +451,18 @@ export async function grafanaProxyMiddleware(req, res, next) {
     response.headers.forEach((v, k) => {
       const lower = k.toLowerCase();
       if (lower === 'x-frame-options' || lower === 'content-security-policy') return;
-      if (lower !== 'transfer-encoding' && lower !== 'content-encoding') {
-        res.setHeader(k, v);
+      if (lower === 'transfer-encoding' || lower === 'content-encoding') return;
+      if (lower === 'set-cookie') {
+        const existing = res.getHeader('set-cookie');
+        const incoming = Array.isArray(v) ? v : [v];
+        const merged = [...(Array.isArray(existing) ? existing : existing ? [existing] : []), ...incoming]
+          .filter(Boolean);
+        if (merged.length > 0) {
+          res.setHeader('set-cookie', merged);
+        }
+        return;
       }
+      res.setHeader(k, v);
     });
 
     res.removeHeader('X-Frame-Options');

--- a/backend/src/services/codeGenerator.service.js
+++ b/backend/src/services/codeGenerator.service.js
@@ -43,8 +43,8 @@ w.addEventListener('unhandledrejection',function(e){tm('promise_rejections',1,{p
 if(c.x&&typeof window!=='undefined'){
 w.trackMetric=tm;w.incrementMetric=inc;w.decrementMetric=dec;
 if(d.addEventListener){
-d.addEventListener('click',function(e){var el=e.target.closest('[data-track]');if(el){var n=el.getAttribute('data-track'),v=parseFloat(el.getAttribute('data-value'))||1,l={};Array.from(el.attributes).forEach(function(a){if(a.name.startsWith('data-label-'))l[a.name.slice(11)]=a.value});tm(n,v,l)}},true);
-d.addEventListener('submit',function(e){var el=e.target.closest('form');if(el&&el.hasAttribute('data-track')){var n=el.getAttribute('data-track'),v=parseFloat(el.getAttribute('data-value'))||1,l={};Array.from(el.attributes).forEach(function(a){if(a.name.startsWith('data-label-'))l[a.name.slice(11)]=a.value});tm(n,v,l)}},true)
+d.addEventListener('click',function(e){var el=e.target.closest('[data-vizme-track]');if(el){var n=el.getAttribute('data-vizme-track'),v=parseFloat(el.getAttribute('data-vizme-value'))||1,l={};Array.from(el.attributes).forEach(function(a){if(a.name.startsWith('data-vizme-label-'))l[a.name.slice(17)]=a.value});tm(n,v,l)}},true);
+d.addEventListener('submit',function(e){var el=e.target.closest('form');if(el&&el.hasAttribute('data-vizme-track')){var n=el.getAttribute('data-vizme-track'),v=parseFloat(el.getAttribute('data-vizme-value'))||1,l={};Array.from(el.attributes).forEach(function(a){if(a.name.startsWith('data-vizme-label-'))l[a.name.slice(17)]=a.value});tm(n,v,l)}},true)
 }
 }
 if(typeof window!=='undefined'&&w.addEventListener){
@@ -54,8 +54,8 @@ w.addEventListener('visibilitychange',function(){if(d.hidden){pb()}})
 if(c.i&&typeof window!=='undefined'&&typeof document!=='undefined'){
 var _d=document,_lc={ts:0,id:''},DD=300,TT=['BUTTON','A','INPUT','SELECT','TEXTAREA'];
 function fta(t){var el=t,dp=0;while(el&&el!==_d&&dp<5){if(TT.indexOf(el.tagName)!==-1||(el.getAttribute&&el.getAttribute('role')==='button'))return el;el=el.parentNode;dp++}return null}
-_d.addEventListener('click',function(e){var el=fta(e.target);if(!el)return;if(el.hasAttribute&&el.hasAttribute('data-track'))return;var eid=(el.id||'')+'|'+(el.tagName||''),now=Date.now();if(eid===_lc.id&&now-_lc.ts<DD)return;_lc={ts:now,id:eid};var l={page:location.pathname,element:el.tagName.toLowerCase(),interaction_type:'click'};if(el.id)l.element_id=el.id;var tx=(el.innerText||'').substring(0,50).trim();if(tx)l.element_text=tx;if(el.href)l.element_href=el.href.substring(0,200);am({n:'user_interaction',t:'counter',v:1,l:l})},true);
-_d.addEventListener('change',function(e){var el=e.target;if(TT.indexOf(el.tagName)===-1||el.tagName==='BUTTON'||el.tagName==='A')return;if(el.hasAttribute&&el.hasAttribute('data-track'))return;var l={page:location.pathname,element:el.tagName.toLowerCase(),interaction_type:'input_change'};if(el.id)l.element_id=el.id;else if(el.name)l.element_id=el.name;if(el.type)l.input_type=el.type;am({n:'user_interaction',t:'counter',v:1,l:l})},true)
+_d.addEventListener('click',function(e){var el=fta(e.target);if(!el)return;if(el.hasAttribute&&el.hasAttribute('data-vizme-track'))return;var eid=(el.id||'')+'|'+(el.tagName||''),now=Date.now();if(eid===_lc.id&&now-_lc.ts<DD)return;_lc={ts:now,id:eid};var l={page:location.pathname,element:el.tagName.toLowerCase(),interaction_type:'click'};if(el.id)l.element_id=el.id;var tx=(el.innerText||'').substring(0,50).trim();if(tx)l.element_text=tx;if(el.href)l.element_href=el.href.substring(0,200);am({n:'user_interaction',t:'counter',v:1,l:l})},true);
+_d.addEventListener('change',function(e){var el=e.target;if(TT.indexOf(el.tagName)===-1||el.tagName==='BUTTON'||el.tagName==='A')return;if(el.hasAttribute&&el.hasAttribute('data-vizme-track'))return;var l={page:location.pathname,element:el.tagName.toLowerCase(),interaction_type:'input_change'};if(el.id)l.element_id=el.id;else if(el.name)l.element_id=el.name;if(el.type)l.input_type=el.type;am({n:'user_interaction',t:'counter',v:1,l:l})},true)
 }
 if(typeof window!=='undefined'){
 w.MetricsTracker={track:tm,increment:inc,decrement:dec,flush:pb,getQueueSize:function(){return q.length},getBatchSize:function(){return b.length}}

--- a/docs/ENHANCEMENT_SUMMARY.md
+++ b/docs/ENHANCEMENT_SUMMARY.md
@@ -5,35 +5,54 @@
 ### 1. Library Enhancements (Lib/vizme.js) — Zero/Minimal Code Tracking
 
 #### DOM Product Context Extraction
+
 - **Attributes:** `data-vizme-product`, `data-vizme-product-id`, `data-vizme-product-name`, `data-vizme-product-category`, `data-vizme-product-price`, `data-vizme-product-currency`
 - **Aliases:** `data-product`, `data-product-id`, etc.
 - **Zero-code example:**
   ```html
-  <div data-vizme-product data-vizme-product-id="123" data-vizme-product-name="Blue Widget"
-       data-vizme-product-category="electronics" data-vizme-product-price="29.99">
+  <div
+    data-vizme-product
+    data-vizme-product-id="123"
+    data-vizme-product-name="Blue Widget"
+    data-vizme-product-category="electronics"
+    data-vizme-product-price="29.99"
+  >
     <button data-vizme-track="add_to_cart" data-vizme-value="1">Add to Cart</button>
   </div>
   ```
 
 #### Value-from-Element (`data-vizme-value-from`)
+
 - Read value from another element (e.g. quantity input):
   ```html
-  <input type="number" id="qty" value="2">
+  <input type="number" id="qty" value="2" />
   <button data-vizme-track="add_to_cart" data-vizme-value-from="#qty">Add to Cart</button>
   ```
 
 #### Custom Event (`vizme:track`)
+
 - One-line tracking for dynamic flows:
   ```javascript
-  window.dispatchEvent(new CustomEvent('vizme:track', {
-    detail: { event: 'add_to_cart', value: 1, product_id: '123', product_name: 'Widget', category: 'electronics', price: '29.99' }
-  }));
+  window.dispatchEvent(
+    new CustomEvent('vizme:track', {
+      detail: {
+        event: 'add_to_cart',
+        value: 1,
+        product_id: '123',
+        product_name: 'Widget',
+        category: 'electronics',
+        price: '29.99',
+      },
+    })
+  );
   ```
 
 #### Dual Attribute Support
-- Supports both `data-vizme-track` / `data-vizme-value` / `data-vizme-label-*` and `data-track` / `data-value` / `data-label-*`
+
+- Supports both `data-vizme-track` / `data-vizme-value` / `data-vizme-label-*` and `data-vizme-track` / `data-vizme-value` / `data-vizme-label-*`
 
 #### Schema.org Microdata Fallback
+
 - Automatically extracts product info from `[itemtype*="schema.org/Product"]` when no `data-vizme-product` is found
 
 ---
@@ -41,15 +60,18 @@
 ### 2. Grafana User Isolation
 
 #### Backend Grafana Proxy
+
 - **`GET /api/v1/grafana/embed-url`** — Returns signed embed URL (requires JWT). Forces `var-user_id` to the authenticated user.
 - **`GET /grafana/*`** — Proxies to Grafana. Validates embed token, sets cookie for subsequent requests, forces `var-user_id` from token.
 
 #### Grafana Configuration
+
 - Anonymous access disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`)
 - Subpath: `/grafana` (`GF_SERVER_SERVE_FROM_SUB_PATH=true`)
 - Dashboard `user_id` variable: `includeAll: false`, `hide: 2` (locked, not editable)
 
 #### Frontend
+
 - `GrafanaEmbed` fetches embed URL from `/api/v1/grafana/embed-url` and uses it for the iframe
 - "Open Full Dashboard" / "Open Grafana" buttons fetch the URL and open in a new tab
 
@@ -79,18 +101,34 @@
 ### 3. Client Integration (Zero-Code)
 
 **HTML only (no JavaScript):**
+
 ```html
-<div data-vizme-product data-vizme-product-id="123" data-vizme-product-name="Blue Widget"
-     data-vizme-product-category="electronics" data-vizme-product-price="29.99">
+<div
+  data-vizme-product
+  data-vizme-product-id="123"
+  data-vizme-product-name="Blue Widget"
+  data-vizme-product-category="electronics"
+  data-vizme-product-price="29.99"
+>
   <button data-vizme-track="add_to_cart" data-vizme-value="1">Add to Cart</button>
 </div>
 ```
 
 **Minimal JavaScript (dynamic data):**
+
 ```javascript
-window.dispatchEvent(new CustomEvent('vizme:track', {
-  detail: { event: 'add_to_cart', value: quantity, product_id: id, product_name: name, category, price }
-}));
+window.dispatchEvent(
+  new CustomEvent('vizme:track', {
+    detail: {
+      event: 'add_to_cart',
+      value: quantity,
+      product_id: id,
+      product_name: name,
+      category,
+      price,
+    },
+  })
+);
 ```
 
 ### 4. Verify Grafana Isolation
@@ -104,6 +142,7 @@ window.dispatchEvent(new CustomEvent('vizme:track', {
 ### 5. Cookie / SameSite (same-origin embed)
 
 For the Grafana embed cookie to work (avoids 401 on API calls):
+
 - **Dev**: Vite proxies `/grafana` to the backend; embed URL uses `FRONTEND_URL` (localhost:5173) so the iframe loads same-origin.
 - **Prod**: Reverse proxy must proxy `/grafana` to the backend; `FRONTEND_URL` must match where users access the app.
 - `cookieParser` is installed in the backend; cookie path: `/grafana`.
@@ -112,13 +151,13 @@ For the Grafana embed cookie to work (avoids 401 on API calls):
 
 ## Files Changed
 
-| File | Changes |
-|------|---------|
-| `Lib/vizme.js` | Product context, value-from, vizme:track, dual attrs, Schema.org |
-| `backend/src/routes/grafana.routes.js` | New: embed-url, proxy middleware |
-| `backend/index.js` | cookie-parser, grafana routes |
-| `docker/docker-compose.yml` | Grafana subpath, no anonymous |
-| `frontend/src/api/grafana.js` | New: getEmbedUrl |
-| `frontend/src/components/GrafanaEmbed/index.jsx` | Fetch embed URL from API |
-| `frontend/src/pages/Dashboard/index.jsx` | handleOpenGrafana, getEmbedUrl |
-| `docker/grafana/dashboards/metrics-dashboard.json` | uid, lock user_id variable |
+| File                                               | Changes                                                          |
+| -------------------------------------------------- | ---------------------------------------------------------------- |
+| `Lib/vizme.js`                                     | Product context, value-from, vizme:track, dual attrs, Schema.org |
+| `backend/src/routes/grafana.routes.js`             | New: embed-url, proxy middleware                                 |
+| `backend/index.js`                                 | cookie-parser, grafana routes                                    |
+| `docker/docker-compose.yml`                        | Grafana subpath, no anonymous                                    |
+| `frontend/src/api/grafana.js`                      | New: getEmbedUrl                                                 |
+| `frontend/src/components/GrafanaEmbed/index.jsx`   | Fetch embed URL from API                                         |
+| `frontend/src/pages/Dashboard/index.jsx`           | handleOpenGrafana, getEmbedUrl                                   |
+| `docker/grafana/dashboards/metrics-dashboard.json` | uid, lock user_id variable                                       |

--- a/docs/usingCodeSnippet.md
+++ b/docs/usingCodeSnippet.md
@@ -18,6 +18,7 @@ When clients use the code snippet method, they paste a small JavaScript snippet 
 3. These configurations are saved in the database (`metric_configs` table)
 
 **Example:**
+
 - Metric name: `page_views`
 - Type: `counter`
 - Labels: `{ "page": "home" }`
@@ -32,21 +33,23 @@ When clients use the code snippet method, they paste a small JavaScript snippet 
 3. Backend generates a small snippet (~150 bytes)
 
 **Backend Process (`codeGeneration.routes.js`):**
+
 - Validates the API key belongs to the user
 - Calls `generateMinimalSnippet()` function
 - Returns a tiny JavaScript snippet
 
 **The snippet looks like this:**
+
 ```javascript
-(function(w,d,s,l,i){
-  w[l]=w[l]||[];
-  w[l].push({'start':Date.now()});
-  var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s);
-  j.async=true;
-  j.src='http://localhost:3000/api/v1/tracker.js?k=API_KEY&a=1&c=1';
-  f.parentNode.insertBefore(j,f);
-})(window,document,'script','metricsTracker');
+(function (w, d, s, l, i) {
+  w[l] = w[l] || [];
+  w[l].push({ start: Date.now() });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s);
+  j.async = true;
+  j.src = 'http://localhost:3000/api/v1/tracker.js?k=API_KEY&a=1&c=1';
+  f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'metricsTracker');
 ```
 
 ### Step 3: Client Pastes Snippet into Their Website
@@ -56,6 +59,7 @@ When clients use the code snippet method, they paste a small JavaScript snippet 
 3. When the page loads, the snippet runs automatically
 
 **What happens:**
+
 - The snippet creates a `<script>` tag
 - The script tag loads `/api/v1/tracker.js` from your server
 - The URL includes the API key and settings as query parameters
@@ -77,6 +81,7 @@ When the browser requests `/api/v1/tracker.js`, the server:
    - Converts labels from array format to object format
 
 3. **Builds Configuration Object:**
+
    ```javascript
    {
      "page_views": { t: "counter", l: { "page": "home" } },
@@ -94,6 +99,7 @@ When the browser requests `/api/v1/tracker.js`, the server:
    - Sends the generated JavaScript code to the browser
 
 **The generated code includes:**
+
 - API key (embedded)
 - Endpoint URL (where to send metrics)
 - All metric configurations (embedded)
@@ -120,8 +126,8 @@ Once the full library code loads in the browser:
    - Tracks time on page
 
 3. **Custom Event Tracking (if enabled):**
-   - Listens for clicks on elements with `data-track` attribute
-   - Listens for form submissions with `data-track` attribute
+   - Listens for clicks on elements with `data-vizme-track` attribute
+   - Listens for form submissions with `data-vizme-track` attribute
    - Automatically tracks these events
 
 ### Step 6: Metrics Are Collected
@@ -129,15 +135,18 @@ Once the full library code loads in the browser:
 Metrics can be collected in three ways:
 
 **A. Auto-Tracking:**
+
 - Library automatically tracks events (page views, errors, performance)
 - No code needed from client
 
 **B. HTML Attributes:**
+
 ```html
-<button data-track="button_click" data-value="1">Click Me</button>
+<button data-vizme-track="button_click" data-vizme-value="1">Click Me</button>
 ```
 
 **C. JavaScript API:**
+
 ```javascript
 window.MetricsTracker.track('custom_event', 1, { label: 'value' });
 window.MetricsTracker.increment('counter_name', 1);
@@ -145,6 +154,7 @@ window.MetricsTracker.decrement('gauge_name', 1);
 ```
 
 **What happens when a metric is tracked:**
+
 1. Library checks if metric name exists in embedded configs
 2. If found, uses the configured type and labels
 3. If not found, uses default type (gauge) or method default
@@ -154,11 +164,13 @@ window.MetricsTracker.decrement('gauge_name', 1);
 ### Step 7: Metrics Are Batched and Sent
 
 **Batching Process:**
+
 1. Metrics are added to a batch array
 2. When batch reaches 10 metrics (or timer expires after 5 seconds), batch is sent
 3. If send fails, metrics go to queue for retry
 
 **Sending Process (`sendMetrics` function in generated code):**
+
 1. Takes all metrics from batch
 2. Formats them as JSON:
    ```json
@@ -257,4 +269,3 @@ Client Website                    Your Backend                    Database
      | 9. Success response             |                              |
      |<--------------------------------|                              |
 ```
-

--- a/frontend/src/pages/CodeGeneration/index.jsx
+++ b/frontend/src/pages/CodeGeneration/index.jsx
@@ -53,7 +53,7 @@ function CodeGeneration() {
       ]);
 
       const keys = keysRes.data || [];
-      const configs = Array.isArray(configsRes) ? configsRes : (configsRes?.data || []);
+      const configs = Array.isArray(configsRes) ? configsRes : configsRes?.data || [];
 
       setMetricConfigs(configs);
 
@@ -84,10 +84,11 @@ function CodeGeneration() {
     setError('');
 
     try {
-      const response = await codeGenerationAPI.generate(
-        selectedApiKey.id,
-        { autoTrack: autoPageViews, customEvents: true, autoInteractions }
-      );
+      const response = await codeGenerationAPI.generate(selectedApiKey.id, {
+        autoTrack: autoPageViews,
+        customEvents: true,
+        autoInteractions,
+      });
 
       setGeneratedCode(response.data.code);
     } catch (err) {
@@ -135,7 +136,7 @@ ${snippet}
 </script>
 
 <!-- Optional: Track custom events -->
-<!-- <button data-track="button_clicks" data-value="1">Click me</button> -->`,
+<!-- <button data-vizme-track="button_clicks" data-vizme-value="1">Click me</button> -->`,
 
       react: `// VIZME Analytics - ${metricName}
 // Add this to your main App.jsx or index.jsx
@@ -279,7 +280,8 @@ export class VizmeService {
       <div className="cg-config-info">
         <span className="cg-config-badge">
           <CheckIcon size={14} />
-          Covers all {metricConfigs.length} metric configuration{metricConfigs.length !== 1 ? 's' : ''} automatically
+          Covers all {metricConfigs.length} metric configuration
+          {metricConfigs.length !== 1 ? 's' : ''} automatically
         </span>
       </div>
 
@@ -360,7 +362,9 @@ export class VizmeService {
                   onChange={(e) => setAutoInteractions(e.target.checked)}
                   className="cg-checkbox"
                 />
-                <div className="cg-checkbox-custom">{autoInteractions && <CheckIcon size={14} />}</div>
+                <div className="cg-checkbox-custom">
+                  {autoInteractions && <CheckIcon size={14} />}
+                </div>
                 <div className="cg-option-text">
                   <span className="cg-option-label">Auto Interactions</span>
                   <span className="cg-option-desc">

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,27 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
-    }
+      '@': path.resolve(__dirname, './src'),
+    },
   },
   server: {
     port: 5173,
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
-        changeOrigin: true
+        changeOrigin: true,
       },
       // Grafana embed: proxy so iframe loads same-origin (cookie works, avoids 401)
       '/grafana': {
         target: 'http://localhost:3000',
         changeOrigin: true,
-        ws: true
-      }
-    }
-  }
-})
+        ws: true,
+      },
+    },
+  },
+});

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ganesh/vizme",
-  "version": "1.0.2",
+  "name": "vizme",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ganesh/vizme",
-      "version": "1.0.2",
+      "name": "vizme",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ganesh-40/vizme",
-  "version": "1.0.2",
+  "name": "visualizemet",
+  "version": "1.0.3",
   "description": "Unified visibility platform - automatic metrics tracking library",
   "type": "module",
   "main": "./dist/vizme.cjs",

--- a/library/src/index.js
+++ b/library/src/index.js
@@ -659,7 +659,7 @@ class VizmeClient {
         batchSize: config.batchSize || 5,
         flushInterval: config.flushInterval || 1000,
         metricConfigs: config.metricConfigs || {},
-        autofetchConfigs: config.autofetchConfigs !== false,
+        autoFetchConfigs: config.autoFetchConfigs !== false,
         sampleRate: config.sampleRate ?? 1,
         maxRetries: config.maxRetries ?? 5,
         retryBaseMs: config.retryBaseMs ?? 1000,
@@ -679,7 +679,7 @@ class VizmeClient {
       });
 
           // Auto-fetch metric configs from backend
-    if (this.config.autofetchConfigs && !config.metricConfigs) {
+    if (this.config.autoFetchConfigs && !config.metricConfigs) {
       this.configReady = this.fetchMetricConfigs().then(configs=>{
         this.client.metricConfigs = configs;
       })

--- a/library/vizme.d.ts
+++ b/library/vizme.d.ts
@@ -10,7 +10,7 @@ export interface VizmeConstructorOptions {
   /** Enable automatic tracking (default: true) */
   autoTrack?: boolean;
   /** Fetch metric configs from the server (default: true) */
-  autofetchConfigs?: boolean;
+  autoFetchConfigs?: boolean;
   batchSize?: number;
   flushInterval?: number;
   metricConfigs?: Record<string, { type?: string; labels?: Record<string, string> }>;


### PR DESCRIPTION
## Title
Standardize tracking attributes to data-vizme-* across snippet and docs

## What changed
- Updated generated tracking snippet to use `data-vizme-track`, `data-vizme-value`, and `data-vizme-label-*`.
- Updated auto-interaction skip checks to recognize the new `data-vizme-track` opt-in attribute.
- Fixed label key extraction for `data-vizme-label-*` so label names are parsed correctly.
- Updated docs/examples to reflect the canonical `data-vizme-*` attribute scheme.

## Why
We had drift between integrations (`data-track` vs `data-vizme-track`), which caused confusion and inconsistent copy-paste behavior. This PR makes snippet behavior and documentation consistent with the canonical attribute contract.

## Scope
- `backend/src/services/codeGenerator.service.js`
- `docs/usingCodeSnippet.md`
- `docs/ENHANCEMENT_SUMMARY.md`
- `frontend/src/pages/CodeGeneration/index.jsx`

## Test plan
- Generate snippet from UI and verify produced HTML examples use `data-vizme-*`.
- Add a test button with `data-vizme-track` and confirm metric POST is sent.
- Confirm labels from `data-vizme-label-*` appear with correct key names in payload.