### PR TITLE
Update package names  & versions and library published to npm

### DIFF
--- a/backend/src/routes/grafana.routes.js
+++ b/backend/src/routes/grafana.routes.js
@@ -175,9 +175,7 @@ router.get('/embed-url', grafanaEmbedLimiter, authenticate, async (req, res, nex
     });
 
     const path =
-      dashboard === 'metrics'
-        ? `d/${dashboard}/${METRICS_DASHBOARD_SLUG}`
-        : `d/${dashboard}`;
+      dashboard === 'metrics' ? `d/${dashboard}/${METRICS_DASHBOARD_SLUG}` : `d/${dashboard}`;
     const url = `${baseUrl}/grafana/${path}?${params.toString()}`;
 
     if (wantsBrowserRedirect(req)) {
@@ -251,6 +249,23 @@ function buildGrafanaProxyTargetUrl(path, queryStr, upstreamOrigin) {
   const prefix = useSubpath ? '/grafana' : '';
   const qs = queryStr ? `?${queryStr}` : '';
   return `${upstreamOrigin}${prefix}${path}${qs}`;
+}
+
+function isGrafanaStaticAssetPath(path = '') {
+  return /^\/public\/build\//.test(path) || /^\/public\/plugins\//.test(path);
+}
+
+function isGrafanaOptionalFeaturePath(path = '') {
+  return (
+    path.includes('/apis/features.grafana.app/') ||
+    path.includes('/ofrep/v1/evaluate/flags')
+  );
+}
+
+function shouldClearEmbedCookieOnUpstreamAuthFailure(path = '', status) {
+  if (status !== 401 && status !== 403) return false;
+  if (isGrafanaStaticAssetPath(path) || isGrafanaOptionalFeaturePath(path)) return false;
+  return true;
 }
 
 /**
@@ -380,11 +395,7 @@ export async function grafanaProxyMiddleware(req, res, next) {
 
     let response = await fetch(targetUrl, fetchOpts);
 
-    if (
-      response.status === 404 &&
-      req.method === 'GET' &&
-      /^\/d\//.test(path)
-    ) {
+    if (response.status === 404 && req.method === 'GET' && /^\/d\//.test(path)) {
       logger.warn(
         {
           path,
@@ -402,7 +413,10 @@ export async function grafanaProxyMiddleware(req, res, next) {
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearGrafanaEmbedCookie(res);
+      const shouldClear = shouldClearEmbedCookieOnUpstreamAuthFailure(path, response.status);
+      if (shouldClear) {
+        clearGrafanaEmbedCookie(res);
+      }
       logger.warn(
         {
           status: response.status,
@@ -410,14 +424,22 @@ export async function grafanaProxyMiddleware(req, res, next) {
           method: req.method,
           userId: String(userId),
           orgId: String(orgId),
+          clearedEmbedCookie: shouldClear,
         },
-        'Grafana auth rejection; cleared embed cookie for automatic recovery'
+        shouldClear
+          ? 'Grafana auth rejection on critical path; cleared embed cookie for recovery'
+          : 'Grafana auth rejection on non-critical path; preserved embed cookie'
       );
     }
 
     if (response.status >= 400) {
       logger.warn(
-        { status: response.status, path, targetUrl: targetUrl.replace(/:[^:@]+@/, ':***@'), method: req.method },
+        {
+          status: response.status,
+          path,
+          targetUrl: targetUrl.replace(/:[^:@]+@/, ':***@'),
+          method: req.method,
+        },
         'Grafana proxy non-2xx response'
       );
     }
@@ -429,9 +451,18 @@ export async function grafanaProxyMiddleware(req, res, next) {
     response.headers.forEach((v, k) => {
       const lower = k.toLowerCase();
       if (lower === 'x-frame-options' || lower === 'content-security-policy') return;
-      if (lower !== 'transfer-encoding' && lower !== 'content-encoding') {
-        res.setHeader(k, v);
+      if (lower === 'transfer-encoding' || lower === 'content-encoding') return;
+      if (lower === 'set-cookie') {
+        const existing = res.getHeader('set-cookie');
+        const incoming = Array.isArray(v) ? v : [v];
+        const merged = [...(Array.isArray(existing) ? existing : existing ? [existing] : []), ...incoming]
+          .filter(Boolean);
+        if (merged.length > 0) {
+          res.setHeader('set-cookie', merged);
+        }
+        return;
       }
+      res.setHeader(k, v);
     });
 
     res.removeHeader('X-Frame-Options');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,27 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
-    }
+      '@': path.resolve(__dirname, './src'),
+    },
   },
   server: {
     port: 5173,
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
-        changeOrigin: true
+        changeOrigin: true,
       },
       // Grafana embed: proxy so iframe loads same-origin (cookie works, avoids 401)
       '/grafana': {
         target: 'http://localhost:3000',
         changeOrigin: true,
-        ws: true
-      }
-    }
-  }
-})
+        ws: true,
+      },
+    },
+  },
+});

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ganesh/vizme",
-  "version": "1.0.2",
+  "name": "vizme",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ganesh/vizme",
-      "version": "1.0.2",
+      "name": "vizme",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.25.0"

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ganesh-40/vizme",
-  "version": "1.0.2",
+  "name": "visualizemet",
+  "version": "1.0.3",
   "description": "Unified visibility platform - automatic metrics tracking library",
   "type": "module",
   "main": "./dist/vizme.cjs",

--- a/library/src/index.js
+++ b/library/src/index.js
@@ -659,7 +659,7 @@ class VizmeClient {
         batchSize: config.batchSize || 5,
         flushInterval: config.flushInterval || 1000,
         metricConfigs: config.metricConfigs || {},
-        autofetchConfigs: config.autofetchConfigs !== false,
+        autoFetchConfigs: config.autoFetchConfigs !== false,
         sampleRate: config.sampleRate ?? 1,
         maxRetries: config.maxRetries ?? 5,
         retryBaseMs: config.retryBaseMs ?? 1000,
@@ -679,7 +679,7 @@ class VizmeClient {
       });
 
           // Auto-fetch metric configs from backend
-    if (this.config.autofetchConfigs && !config.metricConfigs) {
+    if (this.config.autoFetchConfigs && !config.metricConfigs) {
       this.configReady = this.fetchMetricConfigs().then(configs=>{
         this.client.metricConfigs = configs;
       })

--- a/library/vizme.d.ts
+++ b/library/vizme.d.ts
@@ -10,7 +10,7 @@ export interface VizmeConstructorOptions {
   /** Enable automatic tracking (default: true) */
   autoTrack?: boolean;
   /** Fetch metric configs from the server (default: true) */
-  autofetchConfigs?: boolean;
+  autoFetchConfigs?: boolean;
   batchSize?: number;
   flushInterval?: number;
   metricConfigs?: Record<string, { type?: string; labels?: Record<string, string> }>;


### PR DESCRIPTION
## Title
Align JS SDK package name and config contract for npm usage

## What changed
- Set the library to a canonical npm package name (`visualizemet`).
- Standardized config key casing to `autoFetchConfigs` across runtime and types.
- Updated package metadata/lockfile for release consistency.

## How users install and use
```bash
npm i visualizemet
```
```js
import Vizme from  'visualizemet'

const vizme = new Vizme({
  apiKey: 'YOUR_API_KEY',
  endpoint: 'https://your-api-domain/api/v1/metrics',
  autoFetchConfigs: true
})```