### PR TITLE
feat: Add Vizme Python SDK with client and metric models

### DIFF
--- a/pyLibrary/README.md
+++ b/pyLibrary/README.md
@@ -1,0 +1,71 @@
+# Vizme Python Library
+
+Minimal Python SDK for sending metrics to Vizme backend ingestion endpoint.
+
+## Install
+
+```bash
+pip install -e .
+```
+
+From inside `pyLibrary`, this installs the local package in editable mode.
+
+## Quick Start
+
+```python
+from vizme import VizmeClient
+
+client = VizmeClient(
+    api_key="mk_your_api_key_here",
+    endpoint="http://localhost:3000/api/v1/metrics",
+)
+
+response = client.send_metric(
+    name="checkout_started",
+    metric_type="counter",
+    value=1,
+    labels={"page": "/pricing", "plan": "pro"},
+)
+
+print(response)
+```
+
+## Send Batch
+
+```python
+from vizme import Metric, VizmeClient
+
+client = VizmeClient(
+    api_key="mk_your_api_key_here",
+    endpoint="http://localhost:3000/api/v1/metrics",
+)
+
+response = client.send_batch(
+    [
+        Metric(name="page_views", metric_type="counter", value=1, labels={"page": "/home"}),
+        Metric(name="api_latency_ms", metric_type="histogram", value=123.4, labels={"route": "/orders"}),
+        {
+            "name": "active_users",
+            "type": "gauge",
+            "value": 57,
+            "labels": {"region": "in"},
+            "operation": "set",
+        },
+    ]
+)
+
+print(response)
+```
+
+## Helpers
+
+```python
+client.increment("orders_created", value=1, labels={"source": "web"})
+client.gauge("queue_depth", value=12, labels={"queue": "emails"})
+```
+
+## Notes
+
+- Endpoint payload matches existing JS ingestion shape: `{"metrics":[...]}`.
+- Default auth header is `X-API-Key`.
+- Max batch size is 100 metrics per request.

--- a/pyLibrary/pyproject.toml
+++ b/pyLibrary/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vizme-python"
+version = "0.1.0"
+description = "Python client for Vizme metrics ingestion"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [
+  { name = "Vizme Team" }
+]
+dependencies = [
+  "requests>=2.31.0"
+]
+
+[project.urls]
+Homepage = "https://github.com/ganesh-786/Vizme"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pyLibrary/smoke_demo.py
+++ b/pyLibrary/smoke_demo.py
@@ -1,0 +1,53 @@
+"""Smoke demo for Vizme Python SDK.
+
+Usage:
+  export VIZME_API_KEY=<your_api_key>"
+  export VIZME_ENDPOINT=<your_endpoint>
+  python smoke_demo.py
+"""
+
+import os
+import time
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
+
+from vizme import Metric, VizmeClient
+
+
+def main() -> None:
+    api_key = os.getenv("VIZME_API_KEY")
+    endpoint = os.getenv("VIZME_ENDPOINT")
+
+    if not api_key:
+        raise SystemExit("VIZME_API_KEY is required")
+
+    client = VizmeClient(api_key=api_key, endpoint=endpoint)
+    now = int(time.time())
+
+    response = client.send_batch(
+        [
+            Metric(
+                name="python_smoke_counter",
+                metric_type="counter",
+                value=1,
+                labels={"source": "pyLibrary", "run_ts": str(now)},
+                operation="increment",
+            ),
+            Metric(
+                name="python_smoke_gauge",
+                metric_type="gauge",
+                value=42,
+                labels={"source": "pyLibrary", "run_ts": str(now)},
+                operation="set",
+            ),
+        ]
+    )
+
+    print("Ingestion response:", response)
+    print("Now check dashboard for metrics: python_smoke_counter / python_smoke_gauge")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyLibrary/src/vizme/__init__.py
+++ b/pyLibrary/src/vizme/__init__.py
@@ -1,0 +1,21 @@
+"""Vizme Python SDK."""
+
+from .client import VizmeClient
+from .exceptions import (
+    VizmeAuthError,
+    VizmeClientError,
+    VizmeNetworkError,
+    VizmeServerError,
+    VizmeValidationError,
+)
+from .models import Metric
+
+__all__ = [
+    "Metric",
+    "VizmeClient",
+    "VizmeClientError",
+    "VizmeValidationError",
+    "VizmeAuthError",
+    "VizmeServerError",
+    "VizmeNetworkError",
+]

--- a/pyLibrary/src/vizme/client.py
+++ b/pyLibrary/src/vizme/client.py
@@ -1,0 +1,160 @@
+"""HTTP client for sending metrics to Vizme backend."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+import requests
+
+from .exceptions import (
+    VizmeAuthError,
+    VizmeNetworkError,
+    VizmeServerError,
+    VizmeValidationError,
+)
+from .models import Metric
+
+
+class VizmeClient:
+    """Minimal production-minded client for /api/v1/metrics ingestion."""
+
+    def __init__(
+        self,
+        api_key: str,
+        endpoint: str,
+        timeout: float = 5.0,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        if not api_key or not isinstance(api_key, str):
+            raise VizmeValidationError("api_key is required")
+        if not endpoint or not isinstance(endpoint, str):
+            raise VizmeValidationError("endpoint is required")
+
+        self.api_key = api_key
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout = timeout
+        self.session = session or requests.Session()
+
+    def send_metric(
+        self,
+        name: str,
+        metric_type: str,
+        value: Union[int, float],
+        labels: Optional[Dict[str, Any]] = None,
+        operation: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Send a single metric (wrapped as one-item batch)."""
+        metric = Metric(
+            name=name,
+            metric_type=metric_type,
+            value=float(value),
+            labels=labels or {},
+            operation=operation,
+        )
+        return self.send_batch([metric])
+
+    def send_batch(self, metrics: Iterable[Union[Metric, Dict[str, Any]]]) -> Dict[str, Any]:
+        """Send multiple metrics in one POST request."""
+        metric_payloads = self._normalize_metrics(metrics)
+
+        if len(metric_payloads) == 0:
+            raise VizmeValidationError("metrics must contain at least one item")
+        if len(metric_payloads) > 100:
+            raise VizmeValidationError("metrics cannot exceed 100 items per request")
+
+        payload = {"metrics": metric_payloads}
+        headers = {
+            "Content-Type": "application/json",
+            "X-API-Key": self.api_key,
+        }
+
+        try:
+            response = self.session.post(
+                self.endpoint,
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise VizmeNetworkError(f"Network error while sending metrics: {exc}") from exc
+
+        if response.status_code in (401, 403):
+            raise VizmeAuthError(self._error_message(response))
+        if 400 <= response.status_code < 500:
+            raise VizmeValidationError(self._error_message(response))
+        if response.status_code >= 500:
+            raise VizmeServerError(self._error_message(response))
+
+        return self._safe_json(response)
+
+    def increment(
+        self, name: str, value: Union[int, float] = 1, labels: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Convenience helper for counter increment semantics."""
+        return self.send_metric(
+            name=name,
+            metric_type="counter",
+            value=float(value),
+            labels=labels or {},
+            operation="increment",
+        )
+
+    def gauge(
+        self,
+        name: str,
+        value: Union[int, float],
+        labels: Optional[Dict[str, Any]] = None,
+        operation: str = "set",
+    ) -> Dict[str, Any]:
+        """Convenience helper for gauge metrics."""
+        return self.send_metric(
+            name=name,
+            metric_type="gauge",
+            value=float(value),
+            labels=labels or {},
+            operation=operation,
+        )
+
+    @staticmethod
+    def _safe_json(response: requests.Response) -> Dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError:
+            return {"success": response.ok, "status_code": response.status_code, "text": response.text}
+
+    @staticmethod
+    def _error_message(response: requests.Response) -> str:
+        try:
+            body = response.json()
+        except ValueError:
+            body = {"message": response.text}
+        message = body.get("message") or body.get("error") or str(body)
+        return f"HTTP {response.status_code}: {message}"
+
+    @staticmethod
+    def _normalize_metrics(metrics: Iterable[Union[Metric, Dict[str, Any]]]) -> List[Dict[str, Any]]:
+        payloads: List[Dict[str, Any]] = []
+        for metric in metrics:
+            if isinstance(metric, Metric):
+                payloads.append(metric.to_payload())
+                continue
+
+            if isinstance(metric, dict):
+                required = ("name", "type", "value")
+                missing = [key for key in required if key not in metric]
+                if missing:
+                    raise VizmeValidationError(
+                        f"Metric object missing required fields: {', '.join(missing)}"
+                    )
+                normalized = Metric(
+                    name=metric["name"],
+                    metric_type=metric["type"],
+                    value=float(metric["value"]),
+                    labels=metric.get("labels", {}),
+                    operation=metric.get("operation"),
+                )
+                payloads.append(normalized.to_payload())
+                continue
+
+            raise VizmeValidationError("Each metric must be a Metric or dict object")
+        return payloads

--- a/pyLibrary/src/vizme/exceptions.py
+++ b/pyLibrary/src/vizme/exceptions.py
@@ -1,0 +1,21 @@
+"""Custom exception hierarchy for Vizme Python SDK."""
+
+
+class VizmeClientError(Exception):
+    """Base exception for client-side and API errors."""
+
+
+class VizmeValidationError(VizmeClientError):
+    """Raised when metric data is invalid before sending."""
+
+
+class VizmeAuthError(VizmeClientError):
+    """Raised on authentication or authorization failures."""
+
+
+class VizmeServerError(VizmeClientError):
+    """Raised on non-success server responses."""
+
+
+class VizmeNetworkError(VizmeClientError):
+    """Raised on network failures while sending metrics."""

--- a/pyLibrary/src/vizme/models.py
+++ b/pyLibrary/src/vizme/models.py
@@ -1,0 +1,59 @@
+"""Data models for Vizme metric ingestion payloads."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from .exceptions import VizmeValidationError
+
+METRIC_TYPES = {"counter", "gauge", "histogram", "summary"}
+OPERATIONS = {"increment", "decrement", "set"}
+
+
+@dataclass
+class Metric:
+    """Single metric entry in the ingestion payload."""
+
+    name: str
+    metric_type: str
+    value: float
+    labels: Dict[str, Any] = field(default_factory=dict)
+    operation: Optional[str] = None
+
+    def validate(self) -> None:
+        """Validate metric values using backend-compatible rules."""
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise VizmeValidationError("Metric name must be a non-empty string")
+
+        if self.metric_type not in METRIC_TYPES:
+            raise VizmeValidationError(
+                "Metric type must be one of: counter, gauge, histogram, summary"
+            )
+
+        try:
+            numeric_value = float(self.value)
+        except (TypeError, ValueError) as exc:
+            raise VizmeValidationError("Metric value must be numeric") from exc
+
+        if self.metric_type == "counter" and numeric_value < 0:
+            raise VizmeValidationError("Counter metric value must be non-negative")
+
+        if not isinstance(self.labels, dict):
+            raise VizmeValidationError("Metric labels must be an object/dict")
+
+        if self.operation is not None and self.operation not in OPERATIONS:
+            raise VizmeValidationError(
+                "Metric operation must be one of: increment, decrement, set"
+            )
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Return backend-compatible metric payload item."""
+        self.validate()
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "type": self.metric_type,
+            "value": float(self.value),
+            "labels": self.labels or {},
+        }
+        if self.operation is not None:
+            payload["operation"] = self.operation
+        return payload


### PR DESCRIPTION
## Summary

This PR adds a **prototype Python ingestion library** in `pyLibrary` to provide Python parity with existing JS/cURL ingestion.

It keeps the current platform contract unchanged:
- Uses `POST /api/v1/metrics`
- Uses `X-API-Key` by default
- Sends the same payload shape: `{"metrics": [...]}`

> This is a **prototype version** of the Python library, and it works well for core ingestion use-cases.

---

## Included in this PR

- Python package scaffold in `pyLibrary/`
- `VizmeClient` with:
  - `send_metric(...)`
  - `send_batch(...)`
- Metric model + validation
- Custom exception classes
- README usage examples
- `smoke_demo.py` for quick verification

---

## Quick Usage (for clients)

1. Install:
```bash
cd pyLibrary
python3 -m venv .venv
source .venv/bin/activate
pip install -e .

## Usage

### 1. Send a Metric

```python
from vizme import VizmeClient

client = VizmeClient(
    api_key="mk_your_api_key_here",
    endpoint="http://localhost:3000/api/v1/metrics",
)

client.send_metric(
    name="checkout_started",
    metric_type="counter",
    value=1,
    labels={"page": "/pricing"}
)
```

### 2. Smoke Test

```bash
export VIZME_API_KEY="mk_your_api_key_here"
export VIZME_ENDPOINT="http://localhost:3000/api/v1/metrics"
python smoke_demo.py
```

## Notes

- No backend API changes
- No Python-specific endpoint or auth model added
- Designed as a minimal, production-minded baseline for future improvements