### PR TITLE
fix(e2e): stabilize Playwright signup tests and Chromium defaults

### DIFF
--- a/frontend/e2e/signup.spec.ts
+++ b/frontend/e2e/signup.spec.ts
@@ -49,7 +49,7 @@ test.describe('Signup flow', () => {
     await expect(page).not.toHaveURL(/\/signup/, { timeout: 10_000 });
   });
 
-  test('duplicate email shows error message', async ({ page, context }) => {
+  test('duplicate email shows error message', async ({ page, browser }) => {
     const email = uniqueEmail();
 
     // First signup
@@ -59,18 +59,24 @@ test.describe('Signup flow', () => {
     await page.getByRole('button', { name: /create account/i }).click();
     await expect(page).not.toHaveURL(/\/signup/, { timeout: 10_000 });
 
-    // Open fresh page to avoid stale auth state
-    const freshPage = await context.newPage();
-    await freshPage.goto('/signup');
-    await freshPage.getByLabel(/full name/i).waitFor({ state: 'visible' });
-    await freshPage.getByLabel(/full name/i).fill('Duplicate User');
-    await freshPage.getByLabel(/email/i).fill(email);
-    await freshPage.getByLabel(/^password$/i).fill('SecurePass123!');
-    await freshPage.getByRole('button', { name: /create account/i }).click();
+    // New browser context: same context shares localStorage, so GuestRoute would redirect /signup
+    const guestContext = await browser.newContext();
+    const guestPage = await guestContext.newPage();
+    try {
+      await guestPage.goto('/signup');
+      await guestPage.getByLabel(/full name/i).fill('Duplicate User');
+      await guestPage.getByLabel(/email/i).fill(email);
+      await guestPage.getByLabel(/^password$/i).fill('SecurePass123!');
+      await guestPage.getByRole('button', { name: /create account/i }).click();
 
-    await expect(
-      freshPage.getByText(/already exists/i)
-    ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        guestPage
+          .locator('.error-message')
+          .filter({ hasText: /already exists/i })
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await guestContext.close();
+    }
   });
 
   test('password visibility toggle works', async ({ page }) => {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,25 +22,22 @@ export default defineConfig({
 
   timeout: 30_000,
 
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-  ],
+  // Default to Chromium only — matches .github/workflows/e2e.yml and avoids WebKit
+  // system libraries many Linux dev machines lack. Run all: PLAYWRIGHT_ALL_BROWSERS=1 npx playwright test
+  projects:
+    process.env.PLAYWRIGHT_ALL_BROWSERS === '1'
+      ? [
+          { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+          { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+          { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+        ]
+      : [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
+    // Cursor/some tools set CI=1 globally; GITHUB_ACTIONS is only set in GitHub runners.
+    reuseExistingServer: !process.env.GITHUB_ACTIONS,
     timeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary
This PR improves the reliability of end-to-end (Playwright) tests and ensures consistency between local development and GitHub Actions (CI). It also fixes the duplicate email signup test by isolating browser sessions to better reflect real user behavior.

## How to test

- [X] `cd frontend && npx playwright test` (defaults to Chromium)
- [X] Confirm E2E workflow passes on this PR

